### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2021-03-23
+
+This is the first release of otelsql.
+It contains instrumentation for trace and depends on OTel `0.18.0`.
+
+### Added
+
+- Instrumentation for trace.
+- CI files.
+- Example code for a basic usage.
+- Apache-2.0 license.
+
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/XSAM/otelsql/releases/tag/v0.1.0

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -e
+
+help()
+{
+   printf "\n"
+   printf "Usage: $0 -t tag\n"
+   printf "\t-t Unreleased tag. Update all go.mod with this tag.\n"
+   exit 1 # Exit script after printing help
+}
+
+while getopts "t:" opt
+do
+   case "$opt" in
+      t ) TAG="$OPTARG" ;;
+      ? ) help ;; # Print help
+   esac
+done
+
+# Print help in case parameters are empty
+if [ -z "$TAG" ]
+then
+   printf "Tag is missing\n";
+   help
+fi
+
+# Validate semver
+SEMVER_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+if [[ "${TAG}" =~ ${SEMVER_REGEX} ]]; then
+	printf "${TAG} is valid semver tag.\n"
+else
+	printf "${TAG} is not a valid semver tag.\n"
+	exit -1
+fi
+
+TAG_FOUND=`git tag --list ${TAG}`
+if [[ ${TAG_FOUND} = ${TAG} ]] ; then
+        printf "Tag ${TAG} already exists\n"
+        exit -1
+fi
+
+# Get version for version.go
+OTEL_VERSION=$(echo "${TAG}" | grep -o '^v[0-9]\+\.[0-9]\+\.[0-9]\+')
+# Strip leading v
+OTEL_VERSION="${OTEL_VERSION#v}"
+
+cd $(dirname $0)
+
+if ! git diff --quiet; then \
+	printf "Working tree is not clean, can't proceed with the release process\n"
+	git status
+	git diff
+	exit 1
+fi
+
+# Update version.go
+cp ./version.go ./version.go.bak
+sed "s/\(return \"\)[0-9]*\.[0-9]*\.[0-9]*\"/\1${OTEL_VERSION}\"/" ./version.go.bak >./version.go
+rm -f ./version.go.bak
+
+# Update go.mod
+git checkout -b pre_release_${TAG} main
+
+# Run precommit
+make gazelle
+make precommit
+
+# Add changes and commit.
+git add --all
+git commit -m "Prepare for releasing $TAG"
+
+printf "Now run following to verify the changes.\ngit diff main\n"
+printf "\nThen push the changes to upstream\n"

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright Sam Xie
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 help()

--- a/version.go
+++ b/version.go
@@ -17,5 +17,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.0.0"
+	return "0.1.0"
 }


### PR DESCRIPTION
This is the first release of otelsql.
It contains instrumentation for trace and depends on OTel `0.18.0`.

### Added

- Instrumentation for trace.
- CI files.
- Example code for a basic usage.
- Apache-2.0 license.