### PR TITLE
Fix recordSpanError does not set the status of span to Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- otelsql does not set the status of span to Error while recording error. (#5)
+
 ## [0.2.0] - 2021-03-24
 
 ### Changed

--- a/utils.go
+++ b/utils.go
@@ -16,7 +16,8 @@ package otelsql
 
 import (
 	"database/sql/driver"
-
+	
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -27,8 +28,10 @@ func recordSpanError(span trace.Span, opts SpanOptions, err error) {
 	case driver.ErrSkip:
 		if !opts.DisableErrSkip {
 			span.RecordError(err)
+			span.SetStatus(codes.Error, "")
 		}
 	default:
 		span.RecordError(err)
+		span.SetStatus(codes.Error, "")
 	}
 }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-go/pull/1663 removes setting error status from `RecordError`, so I have to set the status of Span explicitly.

Since https://github.com/open-telemetry/opentelemetry-go/pull/1663 does not update the behavior of oteltest, which is fixed in https://github.com/open-telemetry/opentelemetry-go/pull/1729, the tests of `recordSpanError` will not work until the next release (`v0.20.0`) of `go.opentelemetry.io/otel`.