### PR TITLE
Add WithContextualAttributes option

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -35,7 +35,7 @@ func TestNewConfig(t *testing.T) {
 		),
 		SpanOptions: SpanOptions{Ping: true},
 		DBSystem:    "db",
-		Attributes: []attribute.KeyValue{
+		StaticAttributes: []attribute.KeyValue{
 			semconv.DBSystemKey.String(cfg.DBSystem),
 		},
 		SpanNameFormatter: &defaultSpanNameFormatter{},

--- a/conn.go
+++ b/conn.go
@@ -57,7 +57,7 @@ func (c *otConn) Ping(ctx context.Context) (err error) {
 		var span trace.Span
 		ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, MethodConnPing, ""),
 			trace.WithSpanKind(trace.SpanKindClient),
-			trace.WithAttributes(c.cfg.Attributes...),
+			trace.WithAttributes(c.cfg.BuildAttributes(ctx)...),
 		)
 		defer func() {
 			if err != nil {
@@ -88,7 +88,7 @@ func (c *otConn) ExecContext(ctx context.Context, query string, args []driver.Na
 	ctx, span := c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, MethodConnExec, query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			append(c.cfg.Attributes,
+			append(c.cfg.BuildAttributes(ctx),
 				semconv.DBStatementKey.String(query),
 			)...),
 	)
@@ -119,7 +119,7 @@ func (c *otConn) QueryContext(ctx context.Context, query string, args []driver.N
 	queryCtx, span := c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, MethodConnQuery, query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			append(c.cfg.Attributes,
+			append(c.cfg.BuildAttributes(ctx),
 				semconv.DBStatementKey.String(query),
 			)...),
 	)
@@ -142,7 +142,7 @@ func (c *otConn) PrepareContext(ctx context.Context, query string) (stmt driver.
 	ctx, span := c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, MethodConnPrepare, query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			append(c.cfg.Attributes,
+			append(c.cfg.BuildAttributes(ctx),
 				semconv.DBStatementKey.String(query),
 			)...),
 	)
@@ -164,7 +164,7 @@ func (c *otConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.
 
 	beginTxCtx, span := c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, MethodConnBeginTx, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(c.cfg.Attributes...),
+		trace.WithAttributes(c.cfg.BuildAttributes(ctx)...),
 	)
 	defer span.End()
 
@@ -184,7 +184,7 @@ func (c *otConn) ResetSession(ctx context.Context) (err error) {
 
 	ctx, span := c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, MethodConnResetSession, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(c.cfg.Attributes...),
+		trace.WithAttributes(c.cfg.BuildAttributes(ctx)...),
 	)
 	defer span.End()
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -185,7 +185,7 @@ func TestOtConn_Ping(t *testing.T) {
 				span := spanList[1]
 				assert.True(t, span.Ended())
 				assert.Equal(t, trace.SpanKindClient, span.SpanKind())
-				assert.Equal(t, attributesListToMap(cfg.Attributes), span.Attributes())
+				assert.Equal(t, attributesListToMap(cfg.StaticAttributes), span.Attributes())
 				assert.Equal(t, string(MethodConnPing), span.Name())
 				assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 				assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())
@@ -237,7 +237,7 @@ func TestOtConn_ExecContext(t *testing.T) {
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 			assert.Equal(t, attributesListToMap(append([]attribute.KeyValue{semconv.DBStatementKey.String("query")},
-				cfg.Attributes...)), span.Attributes())
+				cfg.StaticAttributes...)), span.Attributes())
 			assert.Equal(t, string(MethodConnExec), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())
@@ -292,7 +292,7 @@ func TestOtConn_QueryContext(t *testing.T) {
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 			assert.Equal(t, attributesListToMap(append([]attribute.KeyValue{semconv.DBStatementKey.String("query")},
-				cfg.Attributes...)), span.Attributes())
+				cfg.StaticAttributes...)), span.Attributes())
 			assert.Equal(t, string(MethodConnQuery), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())
@@ -353,7 +353,7 @@ func TestOtConn_PrepareContext(t *testing.T) {
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 			assert.Equal(t, attributesListToMap(append([]attribute.KeyValue{semconv.DBStatementKey.String("query")},
-				cfg.Attributes...)), span.Attributes())
+				cfg.StaticAttributes...)), span.Attributes())
 			assert.Equal(t, string(MethodConnPrepare), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())
@@ -411,7 +411,7 @@ func TestOtConn_BeginTx(t *testing.T) {
 			span := spanList[1]
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
-			assert.Equal(t, attributesListToMap(cfg.Attributes), span.Attributes())
+			assert.Equal(t, attributesListToMap(cfg.StaticAttributes), span.Attributes())
 			assert.Equal(t, string(MethodConnBeginTx), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())
@@ -468,7 +468,7 @@ func TestOtConn_ResetSession(t *testing.T) {
 			span := spanList[1]
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
-			assert.Equal(t, attributesListToMap(cfg.Attributes), span.Attributes())
+			assert.Equal(t, attributesListToMap(cfg.StaticAttributes), span.Attributes())
 			assert.Equal(t, string(MethodConnResetSession), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())

--- a/option.go
+++ b/option.go
@@ -15,6 +15,8 @@
 package otelsql
 
 import (
+	"context"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -45,7 +47,15 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 // WithAttributes specifies attributes that will be set to each span.
 func WithAttributes(attributes ...attribute.KeyValue) Option {
 	return OptionFunc(func(cfg *config) {
-		cfg.Attributes = attributes
+		cfg.StaticAttributes = attributes
+	})
+}
+
+// WithContextualAttributes specifies functions that generate trace attributes
+// from a context.
+func WithContextualAttributes(funcs ...func(context.Context) []attribute.KeyValue) Option {
+	return OptionFunc(func(cfg *config) {
+		cfg.ContextualAttributes = funcs
 	})
 }
 

--- a/option_test.go
+++ b/option_test.go
@@ -72,6 +72,8 @@ func TestOptions(t *testing.T) {
 }
 
 func TestWithContextualAttributes(t *testing.T) {
+	type key string
+	const k key = "foo"
 	var cfg config
 
 	WithContextualAttributes(func(ctx context.Context) []attribute.KeyValue {
@@ -80,7 +82,7 @@ func TestWithContextualAttributes(t *testing.T) {
 
 	assert.Equal(t, 1, len(cfg.ContextualAttributes))
 
-	ctx := context.WithValue(context.Background(), "foo", "bar")
+	ctx := context.WithValue(context.Background(), k, "bar")
 	attrs := cfg.ContextualAttributes[0](ctx)
 
 	assert.Equal(t, []attribute.KeyValue{attribute.Any("ctx.foo", "bar")}, attrs)

--- a/rows.go
+++ b/rows.go
@@ -41,7 +41,7 @@ type otRows struct {
 func newRows(ctx context.Context, rows driver.Rows, cfg config) *otRows {
 	_, span := cfg.Tracer.Start(ctx, cfg.SpanNameFormatter.Format(ctx, MethodRows, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(cfg.Attributes...),
+		trace.WithAttributes(cfg.BuildAttributes(ctx)...),
 	)
 
 	return &otRows{

--- a/rows_test.go
+++ b/rows_test.go
@@ -188,7 +188,7 @@ func TestNewRows(t *testing.T) {
 	span := spanList[1]
 	assert.False(t, span.Ended())
 	assert.Equal(t, trace.SpanKindClient, span.SpanKind())
-	assert.Equal(t, attributesListToMap(cfg.Attributes), span.Attributes())
+	assert.Equal(t, attributesListToMap(cfg.StaticAttributes), span.Attributes())
 	assert.Equal(t, string(MethodRows), span.Name())
 	assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 	assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())

--- a/sql_test.go
+++ b/sql_test.go
@@ -46,7 +46,7 @@ func TestRegister(t *testing.T) {
 	assert.ElementsMatch(t, []attribute.KeyValue{
 		semconv.DBSystemKey.String("test-db"),
 		attribute.String("foo", "bar"),
-	}, otelDriver.cfg.Attributes)
+	}, otelDriver.cfg.StaticAttributes)
 
 	// Exceed max slot count
 	_, err = Register("test-driver", "test-db")
@@ -65,5 +65,5 @@ func TestWrapDriver(t *testing.T) {
 	assert.ElementsMatch(t, []attribute.KeyValue{
 		semconv.DBSystemKey.String("test-db"),
 		attribute.String("foo", "bar"),
-	}, otelDriver.cfg.Attributes)
+	}, otelDriver.cfg.StaticAttributes)
 }

--- a/stmt.go
+++ b/stmt.go
@@ -53,7 +53,7 @@ func (s *otStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res
 	ctx, span := s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, MethodStmtExec, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			append(s.cfg.Attributes,
+			append(s.cfg.BuildAttributes(ctx),
 				semconv.DBStatementKey.String(s.query),
 			)...),
 	)
@@ -76,7 +76,7 @@ func (s *otStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (ro
 	queryCtx, span := s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, MethodStmtQuery, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			append(s.cfg.Attributes,
+			append(s.cfg.BuildAttributes(ctx),
 				semconv.DBStatementKey.String(s.query),
 			)...),
 	)

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -111,7 +111,7 @@ func TestOtStmt_ExecContext(t *testing.T) {
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 			assert.Equal(t, attributesListToMap(append([]attribute.KeyValue{semconv.DBStatementKey.String("query")},
-				cfg.Attributes...)), span.Attributes())
+				cfg.StaticAttributes...)), span.Attributes())
 			assert.Equal(t, string(MethodStmtExec), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())
@@ -164,7 +164,7 @@ func TestOtStmt_QueryContext(t *testing.T) {
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 			assert.Equal(t, attributesListToMap(append([]attribute.KeyValue{semconv.DBStatementKey.String("query")},
-				cfg.Attributes...)), span.Attributes())
+				cfg.StaticAttributes...)), span.Attributes())
 			assert.Equal(t, string(MethodStmtQuery), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())

--- a/tx.go
+++ b/tx.go
@@ -40,7 +40,7 @@ func newTx(ctx context.Context, tx driver.Tx, cfg config) *otTx {
 func (t *otTx) Commit() (err error) {
 	_, span := t.cfg.Tracer.Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, MethodTxCommit, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(t.cfg.Attributes...),
+		trace.WithAttributes(t.cfg.BuildAttributes(t.ctx)...),
 	)
 	defer span.End()
 
@@ -55,7 +55,7 @@ func (t *otTx) Commit() (err error) {
 func (t *otTx) Rollback() (err error) {
 	_, span := t.cfg.Tracer.Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, MethodTxRollback, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(t.cfg.Attributes...),
+		trace.WithAttributes(t.cfg.BuildAttributes(t.ctx)...),
 	)
 	defer span.End()
 

--- a/tx_test.go
+++ b/tx_test.go
@@ -93,7 +93,7 @@ func TestOtTx_Commit(t *testing.T) {
 			span := spanList[1]
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
-			assert.Equal(t, attributesListToMap(cfg.Attributes), span.Attributes())
+			assert.Equal(t, attributesListToMap(cfg.StaticAttributes), span.Attributes())
 			assert.Equal(t, string(MethodTxCommit), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())
@@ -144,7 +144,7 @@ func TestOtTx_Rollback(t *testing.T) {
 			span := spanList[1]
 			assert.True(t, span.Ended())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
-			assert.Equal(t, attributesListToMap(cfg.Attributes), span.Attributes())
+			assert.Equal(t, attributesListToMap(cfg.StaticAttributes), span.Attributes())
 			assert.Equal(t, string(MethodTxRollback), span.Name())
 			assert.Equal(t, dummySpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 			assert.Equal(t, dummySpan.SpanContext().SpanID(), span.ParentSpanID())

--- a/utils_test.go
+++ b/utils_test.go
@@ -95,7 +95,7 @@ func createDummySpan(ctx context.Context, tracer trace.Tracer) (context.Context,
 func newMockConfig(tracer trace.Tracer) config {
 	return config{
 		Tracer:            tracer,
-		Attributes:        []attribute.KeyValue{defaultattribute},
+		StaticAttributes:        []attribute.KeyValue{defaultattribute},
 		SpanNameFormatter: &defaultSpanNameFormatter{},
 	}
 }


### PR DESCRIPTION
This option enables dynamic attribute generation from a context. During
query execution, the context is passed to each of these functions and
the resulting attributes are attached to the span.