### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.4.0] - 2021-06-25
+
 ### Changed
 
 - Upgrade to v1.0.0-RC1 of `go.opentelemetry.io/otel`. (#15)
@@ -47,7 +49,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/XSAM/otelsql/releases/tag/v0.4.0
 [0.3.0]: https://github.com/XSAM/otelsql/releases/tag/v0.3.0
 [0.2.1]: https://github.com/XSAM/otelsql/releases/tag/v0.2.1
 [0.2.0]: https://github.com/XSAM/otelsql/releases/tag/v0.2.0

--- a/example/go.mod
+++ b/example/go.mod
@@ -5,7 +5,7 @@ go 1.15
 replace github.com/XSAM/otelsql => ../
 
 require (
-	github.com/XSAM/otelsql v0.3.0
+	github.com/XSAM/otelsql v0.4.0
 	github.com/go-sql-driver/mysql v1.5.0
 	go.opentelemetry.io/otel v1.0.0-RC1
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.0-RC1

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.3.0"
+	return "0.4.0"
 }


### PR DESCRIPTION
### Changed

- Upgrade to v1.0.0-RC1 of `go.opentelemetry.io/otel`. (#15)