### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.5.0] - 2021-08-02
+
 ### Changed
 
 - Upgrade OTel to v1.0.0-RC2. (#18)
@@ -53,7 +55,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/XSAM/otelsql/releases/tag/v0.5.0
 [0.4.0]: https://github.com/XSAM/otelsql/releases/tag/v0.4.0
 [0.3.0]: https://github.com/XSAM/otelsql/releases/tag/v0.3.0
 [0.2.1]: https://github.com/XSAM/otelsql/releases/tag/v0.2.1

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.4.0"
+	return "0.5.0"
 }


### PR DESCRIPTION
## [0.5.0] - 2021-08-02

### Changed

- Upgrade OTel to v1.0.0-RC2. (#18)