### PR TITLE
Change example Docker context to repo root

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM golang:alpine AS base
-COPY . /src/
-WORKDIR /src/instrumentation/database/sql/otelsql/example
+COPY . /src/otelsql
+WORKDIR /src/otelsql/example
 
 FROM base
 RUN go install main.go

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -24,6 +24,6 @@ services:
   client:
     build:
       dockerfile: $PWD/Dockerfile
-      context: ../../../../..
+      context: ..
     depends_on:
     - mysql


### PR DESCRIPTION
This keeps Docker from transferring a large amount of unnecessary
content into the build and prevents some permissions errors if the
repo is checked out not very deeply.
