### PR TITLE
toggleable tracing via SpanMethodOptions

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,9 @@ type SpanNameFormatter interface {
 	Format(ctx context.Context, method Method, query string) string
 }
 
+// SpanMethodOptions holds a list of span-able Method(s), those are operations in the database/sql
+type SpanMethodOptions map[Method]bool
+
 type config struct {
 	TracerProvider trace.TracerProvider
 	Tracer         trace.Tracer
@@ -46,6 +49,9 @@ type config struct {
 	// SpanNameFormatter will be called to produce span's name.
 	// Default use method as span name
 	SpanNameFormatter SpanNameFormatter
+
+	// Methods configure which Method should be traced
+	Methods SpanMethodOptions
 }
 
 // SpanOptions holds configuration of tracing span to decide

--- a/methods.go
+++ b/methods.go
@@ -17,7 +17,7 @@ package otelsql
 // Method specifics operation in the database/sql package.
 type Method string
 
-// Method specifics events in the database/sql package.
+// Event specifics events in the database/sql package.
 type Event string
 
 const (

--- a/option.go
+++ b/option.go
@@ -63,3 +63,15 @@ func WithSpanOptions(opts SpanOptions) Option {
 		cfg.SpanOptions = opts
 	})
 }
+
+// WithSpanMethodOptions specifies database operations for tracing.
+func WithSpanMethodOptions(opts ...Method) Option {
+	methods := make(SpanMethodOptions, len(opts))
+	return OptionFunc(func(cfg *config) {
+		for _, opt := range opts {
+			methods[opt] = true
+		}
+		cfg.Methods = methods
+	})
+}
+

--- a/rows.go
+++ b/rows.go
@@ -40,7 +40,7 @@ type otRows struct {
 
 func newRows(ctx context.Context, rows driver.Rows, cfg config) *otRows {
 	var span trace.Span
-	if cfg.SpanOptions.AllowRoot || trace.SpanContextFromContext(ctx).IsValid() {
+	if traceMethod(ctx, cfg, MethodRows) {
 		_, span = cfg.Tracer.Start(ctx, cfg.SpanNameFormatter.Format(ctx, MethodRows, ""),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(cfg.Attributes...),

--- a/utils_test.go
+++ b/utils_test.go
@@ -120,6 +120,11 @@ func newMockConfig(tracer trace.Tracer) config {
 		Tracer:            tracer,
 		Attributes:        []attribute.KeyValue{defaultattribute},
 		SpanNameFormatter: &defaultSpanNameFormatter{},
+		Methods: SpanMethodOptions{
+			MethodConnExec: true,
+			MethodConnQuery: true,
+			MethodRows: true,
+		},
 	}
 }
 


### PR DESCRIPTION
~~Hi, this is a proposal to the issue https://github.com/XSAM/otelsql/issues/22~~

this PR allows toggling database operations. this leaves on
instrumentation config the decision of choosing which operation/method to trace.
this is an initial implementation and serves as presentation of a
possible approach to the functionality.

By default, operations must be explicitly configured

If you agree with the solution, I would move forward to add tests and implement the check for the remaining methods.
Any suggestion is welcome.

example
```go
func main() {
	driverName, err := otelsql.Register("postgres",
		semconv.DBSystemPostgreSQL.Value.AsString(),
		otelsql.WithSpanOptions(otelsql.SpanOptions{
			DisableErrSkip: true,
		}),
		otelsql.WithSpanMethodOptions(
                         otelsql.MethodConnQuery,
                         otelsql.MethodConnExec,
                         otelsql.MethodRows,
                ),
	)
	if err != nil {
		panic(err)
	}
}
```