### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-11-05
+
 ### Changed
 
 - Upgrade OTel to v1.1.0. (#37)
@@ -82,7 +84,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/XSAM/otelsql/releases/tag/v0.9.0
 [0.8.0]: https://github.com/XSAM/otelsql/releases/tag/v0.8.0
 [0.7.0]: https://github.com/XSAM/otelsql/releases/tag/v0.7.0
 [0.6.0]: https://github.com/XSAM/otelsql/releases/tag/v0.6.0

--- a/example/go.mod
+++ b/example/go.mod
@@ -5,7 +5,7 @@ go 1.15
 replace github.com/XSAM/otelsql => ../
 
 require (
-	github.com/XSAM/otelsql v0.8.0
+	github.com/XSAM/otelsql v0.0.0
 	github.com/go-sql-driver/mysql v1.6.0
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.8.0"
+	return "0.9.0"
 }


### PR DESCRIPTION
## 0.9.0 - 2021-11-05

### Changed

- Upgrade OTel to v1.1.0. (#37)