### PR TITLE
Ignore submod of the otel for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
     schedule:
       day: sunday
       interval: weekly
+    ignore:
+      - dependency-name: "go.opentelemetry.io/otel/*"
   -
     package-ecosystem: gomod
     directory: /example
@@ -29,3 +31,5 @@ updates:
     schedule:
       day: sunday
       interval: weekly
+    ignore:
+      - dependency-name: "go.opentelemetry.io/*"


### PR DESCRIPTION
To prevent the overwhelming PR created by the dependabot.