### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Added
-
-- Add Go 1.18 to supported versions. (#69)
-
 ## [0.12.0] - 2022-03-18
 
 ### Added
 
 - Covering connector's connect method with span. (#66)
+- Add Go 1.18 to supported versions. (#69)
 
 ### Changed
 


### PR DESCRIPTION
## 0.12.0 - 2022-03-18

### Added

- Covering connector's connect method with span. (#66)
- Add Go 1.18 to supported versions. (#69)

### Changed

- Upgrade OTel to `v1.5.0`. (#67)