### PR TITLE
Add Open and OpenDB methods to connect database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Metrics support. (#74)
+- Add `Open` and `OpenDB` methods to instrument `database/sql`. (#77)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ if err != nil {
 }
 ```
 
-See [godoc](https://pkg.go.dev/mod/github.com/XSAM/otelsql) and [a docker-compose example](./example/main.go) for details.
+See [godoc](https://pkg.go.dev/mod/github.com/XSAM/otelsql) and [a docker-compose example](./example/README.md) for details.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ It instruments traces and metrics.
 $ go get github.com/XSAM/otelsql
 ```
 
+## Usage
+
+This project provides four different ways to instrument `database/sql`:
+
+`otelsql.Open`, `otelsql.OpenDB`, `otesql.Register` and `otelsql.WrapDriver`.
+
+And then use `otelsql.RegisterDBStatsMetrics` to instrument `sql.DBStats` with metrics.
+
+```go
+db, err := otelsql.Open("mysql", mysqlDSN, semconv.DBSystemMySQL.Value.AsString())
+if err != nil {
+	panic(err)
+}
+defer db.Close()
+
+err = otelsql.RegisterDBStatsMetrics(db, semconv.DBSystemMySQL.Value.AsString())
+if err != nil {
+	panic(err)
+}
+```
+
+See [godoc](https://pkg.go.dev/mod/github.com/XSAM/otelsql) and [a docker-compose example](./example/main.go) for details.
+
 ## Features
 
 | Feature                    | Description                                                                                                | Status                                | Reason                                                                                                                                                                                                                       |
@@ -32,21 +55,17 @@ $ go get github.com/XSAM/otelsql
 
 ## Metric Instruments
 
-| Name                                         | Description                                                      | Units | Instrument Type      | Value Type | Attribute Key(s) | Attribute Values                    |
-| -------------------------------------------- | ---------------------------------------------------------------- | ----- | -------------------- | ---------- | ---------------- | ----------------------------------- |
-| db.sql.latency                               | The latency of calls in milliseconds                             | ms    | Histogram            | float64    | status           | ok, error                           |
+| Name                                         | Description                                                      | Units | Instrument Type      | Value Type | Attribute Key(s) | Attribute Values                   |
+| -------------------------------------------- | ---------------------------------------------------------------- | ----- | -------------------- | ---------- | ---------------- | ---------------------------------- |
+| db.sql.latency                               | The latency of calls in milliseconds                             | ms    | Histogram            | float64    | status           | ok, error                          |
 |                                              |                                                                  |       |                      |            | method           | method name, like `sql.conn.query` |
-| db.sql.connection.max_open                   | Maximum number of open connections to the database               |       | Asynchronous Gauge   | int64      |                  |                                     |
-| db.sql.connection.open                       | The number of established connections both in use and idle       |       | Asynchronous Gauge   | int64      | status           | idle, inuse                         |
-| db.sql.connection.wait_total                 | The total number of connections waited for                       |       | Asynchronous Counter | int64      |                  |                                     |
-| db.sql.connection.wait_duration_total        | The total time blocked waiting for a new connection              | ms    | Asynchronous Counter | float64    |                  |                                     |
-| db.sql.connection.closed_max_idle_total      | The total number of connections closed due to SetMaxIdleConns    |       | Asynchronous Counter | int64      |                  |                                     |
-| db.sql.connection.closed_max_idle_time_total | The total number of connections closed due to SetConnMaxIdleTime |       | Asynchronous Counter | int64      |                  |                                     |
-| db.sql.connection.closed_max_lifetime_total  | The total number of connections closed due to SetConnMaxLifetime |       | Asynchronous Counter | int64      |                  |                                     |
-
-## Example
-
-See [example](./example/main.go)
+| db.sql.connection.max_open                   | Maximum number of open connections to the database               |       | Asynchronous Gauge   | int64      |                  |                                    |
+| db.sql.connection.open                       | The number of established connections both in use and idle       |       | Asynchronous Gauge   | int64      | status           | idle, inuse                        |
+| db.sql.connection.wait_total                 | The total number of connections waited for                       |       | Asynchronous Counter | int64      |                  |                                    |
+| db.sql.connection.wait_duration_total        | The total time blocked waiting for a new connection              | ms    | Asynchronous Counter | float64    |                  |                                    |
+| db.sql.connection.closed_max_idle_total      | The total number of connections closed due to SetMaxIdleConns    |       | Asynchronous Counter | int64      |                  |                                    |
+| db.sql.connection.closed_max_idle_time_total | The total number of connections closed due to SetConnMaxIdleTime |       | Asynchronous Counter | int64      |                  |                                    |
+| db.sql.connection.closed_max_lifetime_total  | The total number of connections closed due to SetConnMaxLifetime |       | Asynchronous Counter | int64      |                  |                                    |
 
 ## Compatibility
 

--- a/driver.go
+++ b/driver.go
@@ -30,10 +30,14 @@ type otDriver struct {
 
 func newDriver(dri driver.Driver, cfg config) driver.Driver {
 	if _, ok := dri.(driver.DriverContext); ok {
-		return &otDriver{driver: dri, cfg: cfg}
+		return newOtDriver(dri, cfg)
 	}
 	// Only implements driver.Driver
-	return struct{ driver.Driver }{&otDriver{driver: dri, cfg: cfg}}
+	return struct{ driver.Driver }{newOtDriver(dri, cfg)}
+}
+
+func newOtDriver(dri driver.Driver, cfg config) *otDriver {
+	return &otDriver{driver: dri, cfg: cfg}
 }
 
 func (d *otDriver) Open(name string) (driver.Conn, error) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -31,6 +31,10 @@ type mockDriver struct {
 	openName                      string
 }
 
+func NewMockDriver() *mockDriver {
+	return newMockDriver(false)
+}
+
 func newMockDriver(shouldError bool) *mockDriver {
 	return &mockDriver{shouldError: shouldError}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -33,7 +33,7 @@ import (
 	selector "go.opentelemetry.io/otel/sdk/metric/selector/simple"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 
 	"github.com/XSAM/otelsql"
 )
@@ -90,14 +90,8 @@ func main() {
 	initTracer()
 	initMeter()
 
-	// Register an OTel driver
-	driverName, err := otelsql.Register("mysql", semconv.DBSystemMySQL.Value.AsString())
-	if err != nil {
-		panic(err)
-	}
-
 	// Connect to database
-	db, err := sql.Open(driverName, mysqlDSN)
+	db, err := otelsql.Open("mysql", mysqlDSN, semconv.DBSystemMySQL.Value.AsString())
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,80 @@
+// Copyright Sam Xie
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsql_test
+
+import (
+	"database/sql"
+	"database/sql/driver"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+
+	"github.com/XSAM/otelsql"
+)
+
+func init() {
+	sql.Register("mysql", otelsql.NewMockDriver())
+}
+
+var (
+	connector = driver.Connector(nil)
+	dri       = otelsql.NewMockDriver()
+	mysqlDSN  = "root:otel_password@db"
+)
+
+func ExampleOpen() {
+	// Connect to database
+	db, err := otelsql.Open("mysql", mysqlDSN, semconv.DBSystemMySQL.Value.AsString())
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+	// Output:
+}
+
+func ExampleOpenDB() {
+	// Connect to database
+	db := otelsql.OpenDB(connector, semconv.DBSystemMySQL.Value.AsString())
+	defer db.Close()
+}
+
+func ExampleWrapDriver() {
+	otDriver := otelsql.WrapDriver(dri, semconv.DBSystemMySQL.Value.AsString())
+
+	connector, err := otDriver.(driver.DriverContext).OpenConnector(mysqlDSN)
+	if err != nil {
+		panic(err)
+	}
+
+	// Connect to database
+	db := sql.OpenDB(connector)
+	defer db.Close()
+	// Output:
+}
+
+func ExampleRegister() {
+	// Register an OTel driver
+	driverName, err := otelsql.Register("mysql", semconv.DBSystemMySQL.Value.AsString())
+	if err != nil {
+		panic(err)
+	}
+
+	// Connect to database
+	db, err := otelsql.Open(driverName, mysqlDSN, semconv.DBSystemMySQL.Value.AsString())
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+	// Output:
+}

--- a/sql.go
+++ b/sql.go
@@ -127,7 +127,7 @@ func OpenDB(c driver.Connector, dbSystem string, options ...Option) *sql.DB {
 	return sql.OpenDB(connector)
 }
 
-// RegisterDBStatsMetrics register DBStats metrics with OTel instrumentation.
+// RegisterDBStatsMetrics register sql.DBStats metrics with OTel instrumentation.
 func RegisterDBStatsMetrics(db *sql.DB, dbSystem string, opts ...Option) error {
 	cfg := newConfig(dbSystem, opts...)
 	meter := cfg.Meter

--- a/sql.go
+++ b/sql.go
@@ -84,6 +84,49 @@ func WrapDriver(dri driver.Driver, dbSystem string, options ...Option) driver.Dr
 	return newDriver(dri, newConfig(dbSystem, options...))
 }
 
+// Open is a wrapper over sql.Open with OTel instrumentation.
+// Parameter dbSystem is an identifier for the database management system (DBMS)
+// product being used.
+//
+// For more information, see semantic conventions for database
+// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md
+func Open(driverName, dataSourceName string, dbSystem string, options ...Option) (*sql.DB, error) {
+	// Retrieve the driver implementation we need to wrap with instrumentation
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		return nil, err
+	}
+	d := db.Driver()
+	if err = db.Close(); err != nil {
+		return nil, err
+	}
+
+	otDriver := newOtDriver(d, newConfig(dbSystem, options...))
+
+	if _, ok := d.(driver.DriverContext); ok {
+		connector, err := otDriver.OpenConnector(dataSourceName)
+		if err != nil {
+			return nil, err
+		}
+		return sql.OpenDB(connector), nil
+	}
+
+	return sql.OpenDB(dsnConnector{dsn: dataSourceName, driver: otDriver}), nil
+}
+
+// OpenDB is a wrapper over sql.OpenDB with OTel instrumentation.
+// Parameter dbSystem is an identifier for the database management system (DBMS)
+// product being used.
+//
+// For more information, see semantic conventions for database
+// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md
+func OpenDB(c driver.Connector, dbSystem string, options ...Option) *sql.DB {
+	d := newOtDriver(c.Driver(), newConfig(dbSystem, options...))
+	connector := newConnector(c, d)
+
+	return sql.OpenDB(connector)
+}
+
 // RegisterDBStatsMetrics register DBStats metrics with OTel instrumentation.
 func RegisterDBStatsMetrics(db *sql.DB, dbSystem string, opts ...Option) error {
 	cfg := newConfig(dbSystem, opts...)


### PR DESCRIPTION
Closes #72

---

> Does this look correct to you, and would it be worth including in an example?

Yeah, it looks good. I can try to include this in examples. Thanks for providing the use case.

Besides, I can add `otelsql.OpenDB` for `sql.OpenDB`, making this more intuitive.

_Originally posted by @XSAM in https://github.com/XSAM/otelsql/issues/72#issuecomment-1076999799_