### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.13.0] - 2022-04-04
+
 ### Added
 
-- Metrics support. (#74)
+- Add Metrics support. (#74)
 - Add `Open` and `OpenDB` methods to instrument `database/sql`. (#77)
 
 ### Changed
@@ -118,7 +120,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/XSAM/otelsql/releases/tag/v0.13.0
 [0.12.0]: https://github.com/XSAM/otelsql/releases/tag/v0.12.0
 [0.11.0]: https://github.com/XSAM/otelsql/releases/tag/v0.11.0
 [0.10.0]: https://github.com/XSAM/otelsql/releases/tag/v0.10.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.12.0"
+	return "0.13.0"
 }


### PR DESCRIPTION
## 0.13.0 - 2022-04-04

### Added

- Add Metrics support. (#74)
- Add `Open` and `OpenDB` methods to instrument `database/sql`. (#77)

### Changed

- Upgrade OTel to `v1.6.0/v0.28.0`. (#74)
- Upgrade OTel to `v1.6.1`. (#76)