### PR TITLE
Remove `dbSystem` parameter from all exported functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### ⚠️ Notice ⚠️
+
+This update is a breaking change of `Open`, `OpenDB`, `Register`, `WrapDriver` and `RegisterDBStatsMetrics` methods.
+Code instrumented with these methods will need to be modified.
+
+### Removed
+
+- Remove `dbSystem` parameter from all exported functions. (#80)
+
 ## [0.13.0] - 2022-04-04
 
 ### Added

--- a/config.go
+++ b/config.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	metricglobal "go.opentelemetry.io/otel/metric/global"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -50,8 +50,6 @@ type config struct {
 	Instruments *instruments
 
 	SpanOptions SpanOptions
-
-	DBSystem string
 
 	// Attributes will be set to each span.
 	Attributes []attribute.KeyValue
@@ -98,22 +96,16 @@ func (f *defaultSpanNameFormatter) Format(ctx context.Context, method Method, qu
 }
 
 // newConfig returns a config with all Options set.
-func newConfig(dbSystem string, options ...Option) config {
+func newConfig(options ...Option) config {
 	cfg := config{
 		TracerProvider:    otel.GetTracerProvider(),
 		MeterProvider:     metricglobal.MeterProvider(),
-		DBSystem:          dbSystem,
 		SpanNameFormatter: &defaultSpanNameFormatter{},
 	}
 	for _, opt := range options {
 		opt.Apply(&cfg)
 	}
 
-	if cfg.DBSystem != "" {
-		cfg.Attributes = append(cfg.Attributes,
-			semconv.DBSystemKey.String(cfg.DBSystem),
-		)
-	}
 	cfg.Tracer = cfg.TracerProvider.Tracer(
 		instrumentationName,
 		trace.WithInstrumentationVersion(Version()),

--- a/config_test.go
+++ b/config_test.go
@@ -22,12 +22,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
 func TestNewConfig(t *testing.T) {
-	cfg := newConfig("db", WithSpanOptions(SpanOptions{Ping: true}))
+	cfg := newConfig(WithSpanOptions(SpanOptions{Ping: true}), WithAttributes(semconv.DBSystemMySQL))
 	assert.Equal(t, config{
 		TracerProvider: otel.GetTracerProvider(),
 		Tracer: otel.GetTracerProvider().Tracer(
@@ -42,9 +42,8 @@ func TestNewConfig(t *testing.T) {
 		// No need to check values of instruments in this part.
 		Instruments: cfg.Instruments,
 		SpanOptions: SpanOptions{Ping: true},
-		DBSystem:    "db",
 		Attributes: []attribute.KeyValue{
-			semconv.DBSystemKey.String(cfg.DBSystem),
+			semconv.DBSystemMySQL,
 		},
 		SpanNameFormatter: &defaultSpanNameFormatter{},
 	}, cfg)

--- a/conn_test.go
+++ b/conn_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 type mockDriver struct {
@@ -63,12 +65,12 @@ var (
 )
 
 func TestNewDriver(t *testing.T) {
-	d := newDriver(newMockDriver(false), config{DBSystem: "test"})
+	d := newDriver(newMockDriver(false), config{Attributes: []attribute.KeyValue{semconv.DBSystemMySQL}})
 
 	otelDriver, ok := d.(*otDriver)
 	require.True(t, ok)
 	assert.Equal(t, newMockDriver(false), otelDriver.driver)
-	assert.Equal(t, config{DBSystem: "test"}, otelDriver.cfg)
+	assert.Equal(t, config{Attributes: []attribute.KeyValue{semconv.DBSystemMySQL}}, otelDriver.cfg)
 }
 
 func TestOtDriver_Open(t *testing.T) {

--- a/example/main.go
+++ b/example/main.go
@@ -91,13 +91,17 @@ func main() {
 	initMeter()
 
 	// Connect to database
-	db, err := otelsql.Open("mysql", mysqlDSN, semconv.DBSystemMySQL.Value.AsString())
+	db, err := otelsql.Open("mysql", mysqlDSN, otelsql.WithAttributes(
+		semconv.DBSystemMySQL,
+	))
 	if err != nil {
 		panic(err)
 	}
 	defer db.Close()
 
-	err = otelsql.RegisterDBStatsMetrics(db, semconv.DBSystemMySQL.Value.AsString())
+	err = otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(
+		semconv.DBSystemMySQL,
+	))
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -18,8 +18,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
-
 	"github.com/XSAM/otelsql"
 )
 
@@ -35,7 +33,7 @@ var (
 
 func ExampleOpen() {
 	// Connect to database
-	db, err := otelsql.Open("mysql", mysqlDSN, semconv.DBSystemMySQL.Value.AsString())
+	db, err := otelsql.Open("mysql", mysqlDSN)
 	if err != nil {
 		panic(err)
 	}
@@ -45,12 +43,12 @@ func ExampleOpen() {
 
 func ExampleOpenDB() {
 	// Connect to database
-	db := otelsql.OpenDB(connector, semconv.DBSystemMySQL.Value.AsString())
+	db := otelsql.OpenDB(connector)
 	defer db.Close()
 }
 
 func ExampleWrapDriver() {
-	otDriver := otelsql.WrapDriver(dri, semconv.DBSystemMySQL.Value.AsString())
+	otDriver := otelsql.WrapDriver(dri)
 
 	connector, err := otDriver.(driver.DriverContext).OpenConnector(mysqlDSN)
 	if err != nil {
@@ -65,13 +63,13 @@ func ExampleWrapDriver() {
 
 func ExampleRegister() {
 	// Register an OTel driver
-	driverName, err := otelsql.Register("mysql", semconv.DBSystemMySQL.Value.AsString())
+	driverName, err := otelsql.Register("mysql")
 	if err != nil {
 		panic(err)
 	}
 
 	// Connect to database
-	db, err := otelsql.Open(driverName, mysqlDSN, semconv.DBSystemMySQL.Value.AsString())
+	db, err := otelsql.Open(driverName, mysqlDSN)
 	if err != nil {
 		panic(err)
 	}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 type mockStmt struct {


### PR DESCRIPTION
Though `db.system` is [a required attribute for Span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes), it is verbose to put it on the parameters. Users can directly use `otelsql.WithAttributes` option to add this attribute.