### PR TITLE
Move the minimum version to Go 1.17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.16
+  DEFAULT_GO_VERSION: 1.17
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -109,7 +109,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: [1.18, 1.17, 1.16]
+        go-version: [1.18, 1.17]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to acomplish this with a self-hosted runner

--- a/README.md
+++ b/README.md
@@ -70,25 +70,17 @@ This project is tested on the following systems.
 | ------- | ---------- | ------------ |
 | Ubuntu  | 1.18       | amd64        |
 | Ubuntu  | 1.17       | amd64        |
-| Ubuntu  | 1.16       | amd64        |
 | Ubuntu  | 1.18       | 386          |
 | Ubuntu  | 1.17       | 386          |
-| Ubuntu  | 1.16       | 386          |
 | MacOS   | 1.18       | amd64        |
 | MacOS   | 1.17       | amd64        |
-| MacOS   | 1.16       | amd64        |
 | Windows | 1.18       | amd64        |
 | Windows | 1.17       | amd64        |
-| Windows | 1.16       | amd64        |
 | Windows | 1.18       | 386          |
 | Windows | 1.17       | 386          |
-| Windows | 1.16       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.
-
-Go 1.18 was added in March of 2022.
-Go 1.16 will be removed around June 2022.
 
 The project follows the [Release Policy](https://golang.org/doc/devel/release#policy) to support major Go releases.
 


### PR DESCRIPTION
This PR removes the support of Go `1.16`. The minimum support is Go `1.17`.