### PR TITLE
Add `Raw` function to `otConn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The minimum supported Go version is `1.17`.
 ### Added
 
 - Option `OmitResetSession` that if set to true will suppress `sql.conn.reset_session` spans. (#87)
+- Function `Raw` to `otConn` to return the underlying driver connection. (#100)
 
 ### Changed
 

--- a/conn.go
+++ b/conn.go
@@ -248,3 +248,9 @@ func (c *otConn) CheckNamedValue(namedValue *driver.NamedValue) error {
 
 	return namedValueChecker.CheckNamedValue(namedValue)
 }
+
+// Raw returns the underlying driver connection
+// Issue: https://github.com/XSAM/otelsql/issues/98
+func (c *otConn) Raw() driver.Conn {
+	return c.Conn
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -612,3 +612,10 @@ func TestOtConn_ResetSession(t *testing.T) {
 		})
 	}
 }
+
+func TestOtConn_Raw(t *testing.T) {
+	raw := newMockConn(false)
+	conn := newConn(raw, config{})
+
+	assert.Equal(t, raw, conn.Raw())
+}


### PR DESCRIPTION
Resolves https://github.com/XSAM/otelsql/issues/98

This PR adds `Raw` function to `otConn` to return the underlying driver connection.