### PR TITLE
Remove `SpanOptions.AllowRoot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The minimum supported Go version is `1.17`.
 
-This update contains a breaking change of the removal of `SpanOptions.AllowRoot`
+This update contains a breaking change of the removal of `SpanOptions.AllowRoot`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The minimum supported Go version is `1.17`.
 
+This update contains a breaking change of the removal of `SpanOptions.AllowRoot`
+
 ### Added
 
 - Option `OmitResetSession` that if set to true will suppress `sql.conn.reset_session` spans. (#87)
@@ -23,6 +25,7 @@ The minimum supported Go version is `1.17`.
 ### Removed
 
 - Support for Go `1.16`. Support is now only for Go `1.17` and Go `1.18`. (#99)
+- `SpanOptions.AllowRoot`. (#101)
 
 ## [0.14.1] - 2022-04-07
 

--- a/config.go
+++ b/config.go
@@ -87,9 +87,6 @@ type SpanOptions struct {
 	// If this is not set it will default to record all errors (possible not ErrSkip, see option
 	// DisableErrSkip).
 	RecordError func(err error) bool
-
-	// AllowRoot, if set to true, will create root spans in absence of existing spans or even context.
-	AllowRoot bool
 }
 
 type defaultSpanNameFormatter struct{}

--- a/conn.go
+++ b/conn.go
@@ -131,9 +131,7 @@ func (c *otConn) QueryContext(ctx context.Context, query string, args []driver.N
 		onDefer(err)
 	}()
 
-	var span trace.Span
-	queryCtx := ctx
-	queryCtx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, query),
+	queryCtx, span := c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(withDBStatement(c.cfg, query)...),
 	)
@@ -186,9 +184,7 @@ func (c *otConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.
 		onDefer(err)
 	}()
 
-	var span trace.Span
-	beginTxCtx := ctx
-	beginTxCtx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
+	beginTxCtx, span := c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(c.cfg.Attributes...),
 	)

--- a/conn_test.go
+++ b/conn_test.go
@@ -137,27 +137,19 @@ var (
 
 func TestOtConn_Ping(t *testing.T) {
 	testCases := []struct {
-		name            string
-		error           bool
-		pingOption      bool
-		allowRootOption bool
-		noParentSpan    bool
+		name         string
+		error        bool
+		pingOption   bool
+		noParentSpan bool
 	}{
 		{
 			name:       "ping enabled",
 			pingOption: true,
 		},
 		{
-			name:            "ping enabled with no parent span, allow root span",
-			pingOption:      true,
-			allowRootOption: true,
-			noParentSpan:    true,
-		},
-		{
-			name:            "ping enabled with no parent span, disallow root span",
-			pingOption:      true,
-			allowRootOption: false,
-			noParentSpan:    true,
+			name:         "ping enabled with no parent span",
+			pingOption:   true,
+			noParentSpan: true,
 		},
 		{
 			name:       "ping enabled with error",
@@ -177,7 +169,6 @@ func TestOtConn_Ping(t *testing.T) {
 			// New conn
 			cfg := newMockConfig(t, tracer)
 			cfg.SpanOptions.Ping = tc.pingOption
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
 
@@ -190,7 +181,7 @@ func TestOtConn_Ping(t *testing.T) {
 
 			spanList := sr.Ended()
 			if tc.pingOption {
-				expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+				expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 				// One dummy span and one span created in Ping
 				require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -200,7 +191,6 @@ func TestOtConn_Ping(t *testing.T) {
 						error:              tc.error,
 						expectedAttributes: cfg.Attributes,
 						expectedMethod:     MethodConnPing,
-						allowRootOption:    tc.allowRootOption,
 						noParentSpan:       tc.noParentSpan,
 						ctx:                mc.pingCtx,
 					})
@@ -219,12 +209,11 @@ func TestOtConn_Ping(t *testing.T) {
 func TestOtConn_ExecContext(t *testing.T) {
 	expectedAttrs := []attribute.KeyValue{semconv.DBStatementKey.String("query")}
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
-		disableQuery    bool
-		attrs           []attribute.KeyValue
+		name         string
+		error        bool
+		noParentSpan bool
+		disableQuery bool
+		attrs        []attribute.KeyValue
 	}{
 		{
 			name:  "no error",
@@ -240,15 +229,9 @@ func TestOtConn_ExecContext(t *testing.T) {
 			attrs: expectedAttrs,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
 			attrs:        expectedAttrs,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
-			attrs:           expectedAttrs,
 		},
 	}
 
@@ -259,7 +242,6 @@ func TestOtConn_ExecContext(t *testing.T) {
 
 			// New conn
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
@@ -272,7 +254,7 @@ func TestOtConn_ExecContext(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and one span created in ExecContext
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -281,7 +263,6 @@ func TestOtConn_ExecContext(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: append(cfg.Attributes, tc.attrs...),
 				expectedMethod:     MethodConnExec,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 				ctx:                mc.execContextCtx,
 			})
@@ -295,12 +276,11 @@ func TestOtConn_ExecContext(t *testing.T) {
 func TestOtConn_QueryContext(t *testing.T) {
 	expectedAttrs := []attribute.KeyValue{semconv.DBStatementKey.String("query")}
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
-		disableQuery    bool
-		attrs           []attribute.KeyValue
+		name         string
+		error        bool
+		noParentSpan bool
+		disableQuery bool
+		attrs        []attribute.KeyValue
 	}{
 		{
 			name:  "no error",
@@ -316,15 +296,9 @@ func TestOtConn_QueryContext(t *testing.T) {
 			attrs: expectedAttrs,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
 			attrs:        expectedAttrs,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
-			attrs:           expectedAttrs,
 		},
 	}
 
@@ -335,7 +309,6 @@ func TestOtConn_QueryContext(t *testing.T) {
 
 			// New conn
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
@@ -348,7 +321,7 @@ func TestOtConn_QueryContext(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and one span created in QueryContext
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -357,7 +330,6 @@ func TestOtConn_QueryContext(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: append(cfg.Attributes, tc.attrs...),
 				expectedMethod:     MethodConnQuery,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 				ctx:                mc.queryContextCtx,
 			})
@@ -389,12 +361,11 @@ func TestOtConn_QueryContext(t *testing.T) {
 func TestOtConn_PrepareContext(t *testing.T) {
 	expectedAttrs := []attribute.KeyValue{semconv.DBStatementKey.String("query")}
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
-		disableQuery    bool
-		attrs           []attribute.KeyValue
+		name         string
+		error        bool
+		noParentSpan bool
+		disableQuery bool
+		attrs        []attribute.KeyValue
 	}{
 		{
 			name:  "no error",
@@ -410,15 +381,9 @@ func TestOtConn_PrepareContext(t *testing.T) {
 			attrs: expectedAttrs,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
 			attrs:        expectedAttrs,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
-			attrs:           expectedAttrs,
 		},
 	}
 
@@ -429,7 +394,6 @@ func TestOtConn_PrepareContext(t *testing.T) {
 
 			// New conn
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
@@ -442,7 +406,7 @@ func TestOtConn_PrepareContext(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and one span created in PrepareContext
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -451,7 +415,6 @@ func TestOtConn_PrepareContext(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: append(cfg.Attributes, tc.attrs...),
 				expectedMethod:     MethodConnPrepare,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 				ctx:                mc.prepareContextCtx,
 			})
@@ -470,10 +433,9 @@ func TestOtConn_PrepareContext(t *testing.T) {
 
 func TestOtConn_BeginTx(t *testing.T) {
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
+		name         string
+		error        bool
+		noParentSpan bool
 	}{
 		{
 			name: "no error",
@@ -483,13 +445,8 @@ func TestOtConn_BeginTx(t *testing.T) {
 			error: true,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
 		},
 	}
 
@@ -500,7 +457,6 @@ func TestOtConn_BeginTx(t *testing.T) {
 
 			// New conn
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
 
@@ -512,7 +468,7 @@ func TestOtConn_BeginTx(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and one span created in BeginTx
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -521,7 +477,6 @@ func TestOtConn_BeginTx(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: cfg.Attributes,
 				expectedMethod:     MethodConnBeginTx,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 				ctx:                mc.beginTxCtx,
 			})
@@ -548,10 +503,9 @@ func TestOtConn_ResetSession(t *testing.T) {
 		}
 		t.Run(testname, func(t *testing.T) {
 			testCases := []struct {
-				name            string
-				error           bool
-				allowRootOption bool
-				noParentSpan    bool
+				name         string
+				error        bool
+				noParentSpan bool
 			}{
 				{
 					name: "no error",
@@ -561,13 +515,8 @@ func TestOtConn_ResetSession(t *testing.T) {
 					error: true,
 				},
 				{
-					name:         "no parent span, disallow root span",
+					name:         "no parent span",
 					noParentSpan: true,
-				},
-				{
-					name:            "no parent span, allow root span",
-					noParentSpan:    true,
-					allowRootOption: true,
 				},
 			}
 
@@ -578,7 +527,6 @@ func TestOtConn_ResetSession(t *testing.T) {
 
 					// New conn
 					cfg := newMockConfig(t, tracer)
-					cfg.SpanOptions.AllowRoot = tc.allowRootOption
 					cfg.SpanOptions.OmitResetSession = omitResetSession
 					mc := newMockConn(tc.error)
 					otelConn := newConn(mc, cfg)
@@ -591,7 +539,7 @@ func TestOtConn_ResetSession(t *testing.T) {
 					}
 
 					spanList := sr.Ended()
-					expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, omitResetSession)
+					expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, omitResetSession)
 					// One dummy span and one span created in ResetSession
 					require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -600,7 +548,6 @@ func TestOtConn_ResetSession(t *testing.T) {
 						error:              tc.error,
 						expectedAttributes: cfg.Attributes,
 						expectedMethod:     MethodConnResetSession,
-						allowRootOption:    tc.allowRootOption,
 						noParentSpan:       tc.noParentSpan,
 						ctx:                mc.resetSessionCtx,
 						omitSpan:           omitResetSession,

--- a/connector.go
+++ b/connector.go
@@ -45,13 +45,11 @@ func (c *otConnector) Connect(ctx context.Context) (connection driver.Conn, err 
 	}()
 
 	var span trace.Span
-	if c.cfg.SpanOptions.AllowRoot || trace.SpanContextFromContext(ctx).IsValid() {
-		ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
-			trace.WithSpanKind(trace.SpanKindClient),
-			trace.WithAttributes(c.cfg.Attributes...),
-		)
-		defer span.End()
-	}
+	ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(c.cfg.Attributes...),
+	)
+	defer span.End()
 
 	connection, err = c.Connector.Connect(ctx)
 	if err != nil {

--- a/connector_test.go
+++ b/connector_test.go
@@ -63,10 +63,9 @@ func TestNewConnector(t *testing.T) {
 
 func TestOtConnector_Connect(t *testing.T) {
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
+		name         string
+		error        bool
+		noParentSpan bool
 	}{
 		{
 			name: "no error",
@@ -76,13 +75,8 @@ func TestOtConnector_Connect(t *testing.T) {
 			error: true,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
 		},
 	}
 
@@ -93,7 +87,6 @@ func TestOtConnector_Connect(t *testing.T) {
 
 			cfg := newMockConfig(t, tracer)
 			mConnector := newMockConnector(nil, tc.error)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			connector := newConnector(mConnector, &otDriver{cfg: cfg})
 			conn, err := connector.Connect(ctx)
 			if tc.error {
@@ -105,7 +98,7 @@ func TestOtConnector_Connect(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and one span created in Connect
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -114,7 +107,6 @@ func TestOtConnector_Connect(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: cfg.Attributes,
 				expectedMethod:     MethodConnectorConnect,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 				ctx:                mConnector.connectContext,
 			})

--- a/rows.go
+++ b/rows.go
@@ -45,12 +45,10 @@ func newRows(ctx context.Context, rows driver.Rows, cfg config) *otRows {
 	method := MethodRows
 	onClose := recordMetric(ctx, cfg.Instruments, cfg.Attributes, method)
 
-	if cfg.SpanOptions.AllowRoot || trace.SpanContextFromContext(ctx).IsValid() {
-		_, span = cfg.Tracer.Start(ctx, cfg.SpanNameFormatter.Format(ctx, method, ""),
-			trace.WithSpanKind(trace.SpanKindClient),
-			trace.WithAttributes(cfg.Attributes...),
-		)
-	}
+	_, span = cfg.Tracer.Start(ctx, cfg.SpanNameFormatter.Format(ctx, method, ""),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(cfg.Attributes...),
+	)
 
 	return &otRows{
 		Rows:    rows,

--- a/rows_test.go
+++ b/rows_test.go
@@ -166,21 +166,15 @@ func TestOtRows_Next(t *testing.T) {
 
 func TestNewRows(t *testing.T) {
 	testCases := []struct {
-		name            string
-		allowRootOption bool
-		noParentSpan    bool
+		name         string
+		noParentSpan bool
 	}{
 		{
 			name: "default config",
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
 		},
 	}
 
@@ -191,13 +185,12 @@ func TestNewRows(t *testing.T) {
 
 			mr := newMockRows(false)
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 
 			// New rows
 			rows := newRows(ctx, mr, cfg)
 
 			spanList := sr.Started()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and one span created in newRows()
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -212,7 +205,6 @@ func TestNewRows(t *testing.T) {
 				error:              false,
 				expectedAttributes: cfg.Attributes,
 				expectedMethod:     MethodRows,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 				spanNotEnded:       true,
 			})

--- a/stmt.go
+++ b/stmt.go
@@ -56,13 +56,11 @@ func (s *otStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res
 	}()
 
 	var span trace.Span
-	if s.cfg.SpanOptions.AllowRoot || trace.SpanContextFromContext(ctx).IsValid() {
-		ctx, span = s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
-			trace.WithSpanKind(trace.SpanKindClient),
-			trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
-		)
-		defer span.End()
-	}
+	ctx, span = s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
+	)
+	defer span.End()
 
 	result, err = execer.ExecContext(ctx, args)
 	if err != nil {
@@ -86,13 +84,11 @@ func (s *otStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (ro
 
 	var span trace.Span
 	queryCtx := ctx
-	if s.cfg.SpanOptions.AllowRoot || trace.SpanContextFromContext(ctx).IsValid() {
-		queryCtx, span = s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
-			trace.WithSpanKind(trace.SpanKindClient),
-			trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
-		)
-		defer span.End()
-	}
+	queryCtx, span = s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
+	)
+	defer span.End()
 
 	rows, err = query.QueryContext(queryCtx, args)
 	if err != nil {

--- a/stmt.go
+++ b/stmt.go
@@ -82,9 +82,7 @@ func (s *otStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (ro
 		onDefer(err)
 	}()
 
-	var span trace.Span
-	queryCtx := ctx
-	queryCtx, span = s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
+	queryCtx, span := s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
 	)

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -76,12 +76,11 @@ var (
 func TestOtStmt_ExecContext(t *testing.T) {
 	expectedAttrs := []attribute.KeyValue{semconv.DBStatementKey.String("query")}
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
-		disableQuery    bool
-		attrs           []attribute.KeyValue
+		name         string
+		error        bool
+		noParentSpan bool
+		disableQuery bool
+		attrs        []attribute.KeyValue
 	}{
 		{
 			name:  "no error",
@@ -97,15 +96,9 @@ func TestOtStmt_ExecContext(t *testing.T) {
 			attrs: expectedAttrs,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
 			attrs:        expectedAttrs,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
-			attrs:           expectedAttrs,
 		},
 	}
 
@@ -117,7 +110,6 @@ func TestOtStmt_ExecContext(t *testing.T) {
 
 			// New stmt
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
 			stmt := newStmt(ms, cfg, "query")
 			// Exec
@@ -129,7 +121,7 @@ func TestOtStmt_ExecContext(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and a span created in tx
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -138,7 +130,6 @@ func TestOtStmt_ExecContext(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: append(cfg.Attributes, tc.attrs...),
 				expectedMethod:     MethodStmtExec,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 			})
 
@@ -151,12 +142,11 @@ func TestOtStmt_ExecContext(t *testing.T) {
 func TestOtStmt_QueryContext(t *testing.T) {
 	expectedAttrs := []attribute.KeyValue{semconv.DBStatementKey.String("query")}
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
-		disableQuery    bool
-		attrs           []attribute.KeyValue
+		name         string
+		error        bool
+		noParentSpan bool
+		disableQuery bool
+		attrs        []attribute.KeyValue
 	}{
 		{
 			name:  "no error",
@@ -172,15 +162,9 @@ func TestOtStmt_QueryContext(t *testing.T) {
 			attrs: expectedAttrs,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
 			attrs:        expectedAttrs,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
-			attrs:           expectedAttrs,
 		},
 	}
 
@@ -192,7 +176,6 @@ func TestOtStmt_QueryContext(t *testing.T) {
 
 			// New stmt
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
 			stmt := newStmt(ms, cfg, "query")
 			// Query
@@ -204,7 +187,7 @@ func TestOtStmt_QueryContext(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and a span created in tx
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -213,7 +196,6 @@ func TestOtStmt_QueryContext(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: append(cfg.Attributes, tc.attrs...),
 				expectedMethod:     MethodStmtQuery,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 			})
 

--- a/tx.go
+++ b/tx.go
@@ -45,13 +45,11 @@ func (t *otTx) Commit() (err error) {
 	}()
 
 	var span trace.Span
-	if t.cfg.SpanOptions.AllowRoot || trace.SpanContextFromContext(t.ctx).IsValid() {
-		_, span = t.cfg.Tracer.Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, method, ""),
-			trace.WithSpanKind(trace.SpanKindClient),
-			trace.WithAttributes(t.cfg.Attributes...),
-		)
-		defer span.End()
-	}
+	_, span = t.cfg.Tracer.Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, method, ""),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(t.cfg.Attributes...),
+	)
+	defer span.End()
 
 	err = t.tx.Commit()
 	if err != nil {
@@ -69,13 +67,11 @@ func (t *otTx) Rollback() (err error) {
 	}()
 
 	var span trace.Span
-	if t.cfg.SpanOptions.AllowRoot || trace.SpanContextFromContext(t.ctx).IsValid() {
-		_, span = t.cfg.Tracer.Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, method, ""),
-			trace.WithSpanKind(trace.SpanKindClient),
-			trace.WithAttributes(t.cfg.Attributes...),
-		)
-		defer span.End()
-	}
+	_, span = t.cfg.Tracer.Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, method, ""),
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(t.cfg.Attributes...),
+	)
+	defer span.End()
 
 	err = t.tx.Rollback()
 	if err != nil {

--- a/tx_test.go
+++ b/tx_test.go
@@ -57,10 +57,9 @@ var defaultattribute = attribute.Key("test").String("foo")
 
 func TestOtTx_Commit(t *testing.T) {
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
+		name         string
+		error        bool
+		noParentSpan bool
 	}{
 		{
 			name: "no error",
@@ -70,13 +69,8 @@ func TestOtTx_Commit(t *testing.T) {
 			error: true,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
 		},
 	}
 
@@ -88,7 +82,6 @@ func TestOtTx_Commit(t *testing.T) {
 
 			// New tx
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			tx := newTx(ctx, mt, cfg)
 			// Commit
 			err := tx.Commit()
@@ -99,7 +92,7 @@ func TestOtTx_Commit(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and one span created in tx
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -108,7 +101,6 @@ func TestOtTx_Commit(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: cfg.Attributes,
 				expectedMethod:     MethodTxCommit,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 			})
 
@@ -119,10 +111,9 @@ func TestOtTx_Commit(t *testing.T) {
 
 func TestOtTx_Rollback(t *testing.T) {
 	testCases := []struct {
-		name            string
-		error           bool
-		allowRootOption bool
-		noParentSpan    bool
+		name         string
+		error        bool
+		noParentSpan bool
 	}{
 		{
 			name: "no error",
@@ -132,13 +123,8 @@ func TestOtTx_Rollback(t *testing.T) {
 			error: true,
 		},
 		{
-			name:         "no parent span, disallow root span",
+			name:         "no parent span",
 			noParentSpan: true,
-		},
-		{
-			name:            "no parent span, allow root span",
-			noParentSpan:    true,
-			allowRootOption: true,
 		},
 	}
 
@@ -150,7 +136,6 @@ func TestOtTx_Rollback(t *testing.T) {
 
 			// New tx
 			cfg := newMockConfig(t, tracer)
-			cfg.SpanOptions.AllowRoot = tc.allowRootOption
 			tx := newTx(ctx, mt, cfg)
 
 			// Rollback
@@ -162,7 +147,7 @@ func TestOtTx_Rollback(t *testing.T) {
 			}
 
 			spanList := sr.Ended()
-			expectedSpanCount := getExpectedSpanCount(tc.allowRootOption, tc.noParentSpan, false)
+			expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, false)
 			// One dummy span and a span created in tx
 			require.Equal(t, expectedSpanCount, len(spanList))
 
@@ -171,7 +156,6 @@ func TestOtTx_Rollback(t *testing.T) {
 				error:              tc.error,
 				expectedAttributes: cfg.Attributes,
 				expectedMethod:     MethodTxRollback,
-				allowRootOption:    tc.allowRootOption,
 				noParentSpan:       tc.noParentSpan,
 			})
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -149,7 +149,6 @@ type spanAssertionParameter struct {
 	error              bool
 	expectedAttributes []attribute.KeyValue
 	expectedMethod     Method
-	allowRootOption    bool
 	noParentSpan       bool
 	ctx                context.Context
 	spanNotEnded       bool
@@ -161,7 +160,7 @@ func assertSpanList(t *testing.T, spanList []sdktrace.ReadOnlySpan, parameter sp
 	if !parameter.omitSpan {
 		if !parameter.noParentSpan {
 			span = spanList[1]
-		} else if parameter.allowRootOption {
+		} else {
 			span = spanList[0]
 		}
 	}
@@ -192,14 +191,14 @@ func assertSpanList(t *testing.T, spanList []sdktrace.ReadOnlySpan, parameter sp
 	}
 }
 
-func getExpectedSpanCount(allowRootOption bool, noParentSpan bool, omitSpan bool) int {
+func getExpectedSpanCount(noParentSpan bool, omitSpan bool) int {
 	if !noParentSpan {
 		if !omitSpan {
 			return 2
 		}
 		return 1
 	}
-	if allowRootOption && !omitSpan {
+	if !omitSpan {
 		return 1
 	}
 	return 0


### PR DESCRIPTION
Resolves https://github.com/XSAM/otelsql/issues/96

This PR also updates the example to indicate the parent span is optional.