### PR TITLE
Add Omit* options to suppress certain spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@ This update contains a breaking change of the removal of `SpanOptions.AllowRoot`
 
 ### Added
 
-- Option `OmitResetSession` that if set to true will suppress `sql.conn.reset_session` spans. (#87)
+- SpanOptions to suppress creation of spans. (#87, #102)
+  - `OmitConnResetSession`
+  - `OmitConnPrepare`
+  - `OmitConnQuery`
+  - `OmitRows`
+  - `OmitConnectorConnect`
+
 - Function `Raw` to `otConn` to return the underlying driver connection. (#100)
 
 ### Changed

--- a/config.go
+++ b/config.go
@@ -75,9 +75,6 @@ type SpanOptions struct {
 	// DisableErrSkip, if set to true, will suppress driver.ErrSkip errors in spans.
 	DisableErrSkip bool
 
-	// OmitResetSession if set to true will suppress sql.conn.reset_session spans
-	OmitResetSession bool
-
 	// DisableQuery if set to true, will suppress db.statement in spans.
 	DisableQuery bool
 
@@ -87,6 +84,21 @@ type SpanOptions struct {
 	// If this is not set it will default to record all errors (possible not ErrSkip, see option
 	// DisableErrSkip).
 	RecordError func(err error) bool
+
+	// OmitConnResetSession if set to true will suppress sql.conn.reset_session spans
+	OmitConnResetSession bool
+
+	// OmitConnPrepare if set to true will suppress sql.conn.prepare spans
+	OmitConnPrepare bool
+
+	// OmitConnQuery if set to true will suppress sql.conn.query spans
+	OmitConnQuery bool
+
+	// OmitRows if set to true will suppress sql.rows spans
+	OmitRows bool
+
+	// OmitConnectorConnect if set to true will suppress sql.connector.connect spans
+	OmitConnectorConnect bool
 }
 
 type defaultSpanNameFormatter struct{}

--- a/connector.go
+++ b/connector.go
@@ -45,11 +45,13 @@ func (c *otConnector) Connect(ctx context.Context) (connection driver.Conn, err 
 	}()
 
 	var span trace.Span
-	ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
-		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(c.cfg.Attributes...),
-	)
-	defer span.End()
+	if !c.cfg.SpanOptions.OmitConnectorConnect {
+		ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
+			trace.WithSpanKind(trace.SpanKindClient),
+			trace.WithAttributes(c.cfg.Attributes...),
+		)
+		defer span.End()
+	}
 
 	connection, err = c.Connector.Connect(ctx)
 	if err != nil {

--- a/rows.go
+++ b/rows.go
@@ -45,10 +45,12 @@ func newRows(ctx context.Context, rows driver.Rows, cfg config) *otRows {
 	method := MethodRows
 	onClose := recordMetric(ctx, cfg.Instruments, cfg.Attributes, method)
 
-	_, span = cfg.Tracer.Start(ctx, cfg.SpanNameFormatter.Format(ctx, method, ""),
-		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(cfg.Attributes...),
-	)
+	if !cfg.SpanOptions.OmitRows {
+		_, span = cfg.Tracer.Start(ctx, cfg.SpanNameFormatter.Format(ctx, method, ""),
+			trace.WithSpanKind(trace.SpanKindClient),
+			trace.WithAttributes(cfg.Attributes...),
+		)
+	}
 
 	return &otRows{
 		Rows:    rows,


### PR DESCRIPTION
Related  https://github.com/XSAM/otelsql/issues/57

Added options:

- OmitConnPrepare
- OmitConnQuery
- OmitRows
- OmitConnectorConnect

Besides, I renamed the `OmitResetSession` to `OmitConnResetSession` for consistency.