### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.15.0] - 2022-07-11
+
 ### ⚠️ Notice ⚠️
 
 The minimum supported Go version is `1.17`.
@@ -164,7 +166,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/XSAM/otelsql/releases/tag/v0.15.0
 [0.14.1]: https://github.com/XSAM/otelsql/releases/tag/v0.14.1
 [0.14.0]: https://github.com/XSAM/otelsql/releases/tag/v0.14.0
 [0.13.0]: https://github.com/XSAM/otelsql/releases/tag/v0.13.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.14.1"
+	return "0.15.0"
 }


### PR DESCRIPTION
## 0.15.0 - 2022-07-11

### ⚠️ Notice ⚠️

The minimum supported Go version is `1.17`.

This update contains a breaking change of the removal of `SpanOptions.AllowRoot`.

### Added

- SpanOptions to suppress creation of spans. (#87, #102)
  - `OmitConnResetSession`
  - `OmitConnPrepare`
  - `OmitConnQuery`
  - `OmitRows`
  - `OmitConnectorConnect`

- Function `Raw` to `otConn` to return the underlying driver connection. (#100)

### Changed

- Upgrade OTel to `v1.7.0`. (#91)
- Upgrade OTel to version `1.8.0/0.31.0`. (#105)

### Removed

- Support for Go `1.16`. Support is now only for Go `1.17` and Go `1.18`. (#99)
- `SpanOptions.AllowRoot`. (#101)