### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.16.0] - 2022-08-25
+
 ### Added
 
 - `WithSQLCommenter` option to enable context propagation for database by injecting a comment into SQL statements. (#112)
@@ -176,7 +178,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/XSAM/otelsql/releases/tag/v0.16.0
 [0.15.0]: https://github.com/XSAM/otelsql/releases/tag/v0.15.0
 [0.14.1]: https://github.com/XSAM/otelsql/releases/tag/v0.14.1
 [0.14.0]: https://github.com/XSAM/otelsql/releases/tag/v0.14.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.15.0"
+	return "0.16.0"
 }


### PR DESCRIPTION
## 0.16.0 - 2022-08-25

### Added

- `WithSQLCommenter` option to enable context propagation for database by injecting a comment into SQL statements. (#112)

  This is an experimental feature and may be changed or removed in a later release.

### Changed

- Upgrade OTel to version `1.9.0`. (#113)