### PR TITLE
Add an option to tag spans with SQL query args

### DIFF
--- a/config.go
+++ b/config.go
@@ -71,6 +71,8 @@ type config struct {
 	SQLCommenter        *commenter
 }
 
+// ArgumentsOptions holds configuration of arguments to decide whether to enable
+// adding query arguments as attributes onto the associated span.
 type ArgumentsOptions struct {
 	// EnableAttributes, if set to true will add query arguments as attributes on the relevant span.
 	EnableAttributes bool

--- a/config.go
+++ b/config.go
@@ -42,7 +42,7 @@ type SpanNameFormatter interface {
 
 type config struct {
 	TracerProvider trace.TracerProvider
-	Tracer         trace.Tracer
+	Tracer         func() trace.Tracer
 
 	MeterProvider metric.MeterProvider
 	Meter         metric.Meter
@@ -128,10 +128,12 @@ func newConfig(options ...Option) config {
 		opt.Apply(&cfg)
 	}
 
-	cfg.Tracer = cfg.TracerProvider.Tracer(
-		instrumentationName,
-		trace.WithInstrumentationVersion(Version()),
-	)
+	cfg.Tracer = func() trace.Tracer {
+		return cfg.TracerProvider.Tracer(
+			instrumentationName,
+			trace.WithInstrumentationVersion(Version()),
+		)
+	}
 	cfg.Meter = cfg.MeterProvider.Meter(
 		instrumentationName,
 		metric.WithInstrumentationVersion(Version()),

--- a/config.go
+++ b/config.go
@@ -42,7 +42,6 @@ type SpanNameFormatter interface {
 
 type config struct {
 	TracerProvider trace.TracerProvider
-	Tracer         func() trace.Tracer
 
 	MeterProvider metric.MeterProvider
 	Meter         metric.Meter
@@ -128,12 +127,6 @@ func newConfig(options ...Option) config {
 		opt.Apply(&cfg)
 	}
 
-	cfg.Tracer = func() trace.Tracer {
-		return cfg.TracerProvider.Tracer(
-			instrumentationName,
-			trace.WithInstrumentationVersion(Version()),
-		)
-	}
 	cfg.Meter = cfg.MeterProvider.Meter(
 		instrumentationName,
 		metric.WithInstrumentationVersion(Version()),
@@ -147,6 +140,13 @@ func newConfig(options ...Option) config {
 	}
 
 	return cfg
+}
+
+func (c *config) Tracer() trace.Tracer {
+	return c.TracerProvider.Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(Version()),
+	)
 }
 
 func withDBStatement(cfg config, query string) []attribute.KeyValue {

--- a/config.go
+++ b/config.go
@@ -164,7 +164,6 @@ func withDBStatement(cfg config, query string, args []driver.NamedValue) []attri
 	attrs := append(cfg.Attributes, semconv.DBStatementKey.String(query))
 	if cfg.ArgumentsOptions.EnableAttributes {
 		for i, arg := range namedToInterface(args) {
-			println(i, arg)
 			attrs = append(attrs, attribute.String(
 				fmt.Sprintf("db.args.%d", i+1),
 				fmt.Sprintf("%v", arg)))

--- a/config.go
+++ b/config.go
@@ -51,7 +51,7 @@ type config struct {
 	Instruments *instruments
 
 	SpanOptions      SpanOptions
-	ArgumentsOptions ArgumentsOptions
+	ArgumentsOptions ArgumentOptions
 
 	// Attributes will be set to each span.
 	Attributes []attribute.KeyValue
@@ -71,9 +71,9 @@ type config struct {
 	SQLCommenter        *commenter
 }
 
-// ArgumentsOptions holds configuration of arguments to decide whether to enable
+// ArgumentOptions holds configuration of arguments to decide whether to enable
 // adding query arguments as attributes onto the associated span.
-type ArgumentsOptions struct {
+type ArgumentOptions struct {
 	// EnableAttributes, if set to true will add query arguments as attributes on the relevant span.
 	EnableAttributes bool
 	// Skip, if set, will be invoked with the current context, query and arguments, and if the func

--- a/config.go
+++ b/config.go
@@ -157,6 +157,13 @@ func newConfig(options ...Option) config {
 	return cfg
 }
 
+func (c *config) Tracer() trace.Tracer {
+	return c.TracerProvider.Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(Version()),
+	)
+}
+
 func withDBStatement(ctx context.Context, cfg config, query string, args []driver.NamedValue) []attribute.KeyValue {
 	if cfg.SpanOptions.DisableQuery {
 		return cfg.Attributes

--- a/config_test.go
+++ b/config_test.go
@@ -28,9 +28,8 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	cfg := newConfig(
-		WithSpanOptions(SpanOptions{Ping: true}),
-		WithAttributes(semconv.DBSystemMySQL),
-		WithArgumentsAttributes(ArgumentOptions{EnableAttributes: true}))
+		WithSpanOptions(SpanOptions{Ping: true, ArgumentOptions: ArgumentOptions{EnableAttributes: true}}),
+		WithAttributes(semconv.DBSystemMySQL))
 	assert.Equal(t, cfg.Tracer(), otel.GetTracerProvider().Tracer(
 		instrumentationName,
 		trace.WithInstrumentationVersion(Version()),
@@ -43,9 +42,8 @@ func TestNewConfig(t *testing.T) {
 			metric.WithInstrumentationVersion(Version()),
 		),
 		// No need to check values of instruments in this part.
-		Instruments:      cfg.Instruments,
-		SpanOptions:      SpanOptions{Ping: true},
-		ArgumentsOptions: ArgumentOptions{EnableAttributes: true},
+		Instruments: cfg.Instruments,
+		SpanOptions: SpanOptions{Ping: true, ArgumentOptions: ArgumentOptions{EnableAttributes: true}},
 		Attributes: []attribute.KeyValue{
 			semconv.DBSystemMySQL,
 		},

--- a/config_test.go
+++ b/config_test.go
@@ -30,7 +30,7 @@ func TestNewConfig(t *testing.T) {
 	cfg := newConfig(
 		WithSpanOptions(SpanOptions{Ping: true}),
 		WithAttributes(semconv.DBSystemMySQL),
-		WithArgumentsAttributes(ArgumentsOptions{EnableAttributes: true}))
+		WithArgumentsAttributes(ArgumentOptions{EnableAttributes: true}))
 	assert.Equal(t, cfg.Tracer(), otel.GetTracerProvider().Tracer(
 		instrumentationName,
 		trace.WithInstrumentationVersion(Version()),
@@ -45,7 +45,7 @@ func TestNewConfig(t *testing.T) {
 		// No need to check values of instruments in this part.
 		Instruments:      cfg.Instruments,
 		SpanOptions:      SpanOptions{Ping: true},
-		ArgumentsOptions: ArgumentsOptions{EnableAttributes: true},
+		ArgumentsOptions: ArgumentOptions{EnableAttributes: true},
 		Attributes: []attribute.KeyValue{
 			semconv.DBSystemMySQL,
 		},

--- a/config_test.go
+++ b/config_test.go
@@ -28,15 +28,8 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	cfg := newConfig(WithSpanOptions(SpanOptions{Ping: true}), WithAttributes(semconv.DBSystemMySQL))
-	assert.Equal(t, cfg.Tracer(), otel.GetTracerProvider().Tracer(
-		instrumentationName,
-		trace.WithInstrumentationVersion(Version()),
-	))
-	// Avoid breaking the assertion below because we're comparing funcs.
-	cfg.Tracer = nil
 	assert.Equal(t, config{
 		TracerProvider: otel.GetTracerProvider(),
-		Tracer:         nil, // Asserted by the assertion above.
 		MeterProvider:  global.MeterProvider(),
 		Meter: global.MeterProvider().Meter(
 			instrumentationName,
@@ -51,5 +44,10 @@ func TestNewConfig(t *testing.T) {
 		SpanNameFormatter: &defaultSpanNameFormatter{},
 		SQLCommenter:      newCommenter(false),
 	}, cfg)
+
+	assert.Equal(t, cfg.Tracer(), otel.GetTracerProvider().Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(Version()),
+	))
 	assert.NotNil(t, cfg.Instruments)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -30,7 +30,7 @@ func TestNewConfig(t *testing.T) {
 	cfg := newConfig(
 		WithSpanOptions(SpanOptions{Ping: true}),
 		WithAttributes(semconv.DBSystemMySQL),
-		WithArgumentsAttributes(ArgumentsOptions{EnableAttributes: true, AttributeNamePrefix: "foo"}))
+		WithArgumentsAttributes(ArgumentsOptions{EnableAttributes: true}))
 	assert.Equal(t, cfg.Tracer(), otel.GetTracerProvider().Tracer(
 		instrumentationName,
 		trace.WithInstrumentationVersion(Version()),
@@ -45,7 +45,7 @@ func TestNewConfig(t *testing.T) {
 		// No need to check values of instruments in this part.
 		Instruments:      cfg.Instruments,
 		SpanOptions:      SpanOptions{Ping: true},
-		ArgumentsOptions: ArgumentsOptions{EnableAttributes: true, AttributeNamePrefix: "foo"},
+		ArgumentsOptions: ArgumentsOptions{EnableAttributes: true},
 		Attributes: []attribute.KeyValue{
 			semconv.DBSystemMySQL,
 		},

--- a/config_test.go
+++ b/config_test.go
@@ -28,13 +28,16 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	cfg := newConfig(WithSpanOptions(SpanOptions{Ping: true}), WithAttributes(semconv.DBSystemMySQL))
+	assert.Equal(t, cfg.Tracer(), otel.GetTracerProvider().Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(Version()),
+	))
+	// Avoid breaking the assertion below because we're comparing funcs.
+	cfg.Tracer = nil
 	assert.Equal(t, config{
 		TracerProvider: otel.GetTracerProvider(),
-		Tracer: otel.GetTracerProvider().Tracer(
-			instrumentationName,
-			trace.WithInstrumentationVersion(Version()),
-		),
-		MeterProvider: global.MeterProvider(),
+		Tracer:         nil, // Asserted by the assertion above.
+		MeterProvider:  global.MeterProvider(),
 		Meter: global.MeterProvider().Meter(
 			instrumentationName,
 			metric.WithInstrumentationVersion(Version()),

--- a/config_test.go
+++ b/config_test.go
@@ -27,7 +27,14 @@ import (
 )
 
 func TestNewConfig(t *testing.T) {
-	cfg := newConfig(WithSpanOptions(SpanOptions{Ping: true}), WithAttributes(semconv.DBSystemMySQL))
+	cfg := newConfig(
+		WithSpanOptions(SpanOptions{Ping: true}),
+		WithAttributes(semconv.DBSystemMySQL),
+		WithArgumentsAttributes(ArgumentsOptions{EnableAttributes: true, AttributeNamePrefix: "foo"}))
+	assert.Equal(t, cfg.Tracer(), otel.GetTracerProvider().Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(Version()),
+	))
 	assert.Equal(t, config{
 		TracerProvider: otel.GetTracerProvider(),
 		MeterProvider:  global.MeterProvider(),
@@ -36,8 +43,9 @@ func TestNewConfig(t *testing.T) {
 			metric.WithInstrumentationVersion(Version()),
 		),
 		// No need to check values of instruments in this part.
-		Instruments: cfg.Instruments,
-		SpanOptions: SpanOptions{Ping: true},
+		Instruments:      cfg.Instruments,
+		SpanOptions:      SpanOptions{Ping: true},
+		ArgumentsOptions: ArgumentsOptions{EnableAttributes: true, AttributeNamePrefix: "foo"},
 		Attributes: []attribute.KeyValue{
 			semconv.DBSystemMySQL,
 		},

--- a/conn.go
+++ b/conn.go
@@ -60,7 +60,7 @@ func (c *otConn) Ping(ctx context.Context) (err error) {
 
 	if c.cfg.SpanOptions.Ping {
 		var span trace.Span
-		ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
+		ctx, span = c.cfg.Tracer().Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(c.cfg.Attributes...),
 		)
@@ -97,7 +97,7 @@ func (c *otConn) ExecContext(ctx context.Context, query string, args []driver.Na
 	}()
 
 	var span trace.Span
-	ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, query),
+	ctx, span = c.cfg.Tracer().Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(withDBStatement(c.cfg, query)...),
 	)
@@ -134,7 +134,7 @@ func (c *otConn) QueryContext(ctx context.Context, query string, args []driver.N
 	var span trace.Span
 	queryCtx := ctx
 	if !c.cfg.SpanOptions.OmitConnQuery {
-		queryCtx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, query),
+		queryCtx, span = c.cfg.Tracer().Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, query),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(withDBStatement(c.cfg, query)...),
 		)
@@ -163,7 +163,7 @@ func (c *otConn) PrepareContext(ctx context.Context, query string) (stmt driver.
 
 	var span trace.Span
 	if !c.cfg.SpanOptions.OmitConnPrepare {
-		ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, query),
+		ctx, span = c.cfg.Tracer().Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, query),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(withDBStatement(c.cfg, query)...),
 		)
@@ -190,7 +190,7 @@ func (c *otConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.
 		onDefer(err)
 	}()
 
-	beginTxCtx, span := c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
+	beginTxCtx, span := c.cfg.Tracer().Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(c.cfg.Attributes...),
 	)
@@ -218,7 +218,7 @@ func (c *otConn) ResetSession(ctx context.Context) (err error) {
 
 	var span trace.Span
 	if !c.cfg.SpanOptions.OmitConnResetSession {
-		ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
+		ctx, span = c.cfg.Tracer().Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(c.cfg.Attributes...),
 		)

--- a/conn_test.go
+++ b/conn_test.go
@@ -262,8 +262,8 @@ func TestOtConn_ExecContext(t *testing.T) {
 
 			// New conn
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
-			cfg.ArgumentsOptions.EnableAttributes = tc.enableArgs
-			cfg.ArgumentsOptions.Skip = tc.skip
+			cfg.SpanOptions.ArgumentOptions.EnableAttributes = tc.enableArgs
+			cfg.SpanOptions.ArgumentOptions.Skip = tc.skip
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
 
@@ -348,7 +348,7 @@ func TestOtConn_QueryContext(t *testing.T) {
 					// New conn
 					cfg.SpanOptions.DisableQuery = tc.disableQuery
 					cfg.SpanOptions.OmitConnQuery = omitConnQuery
-					cfg.ArgumentsOptions.EnableAttributes = tc.enableArgs
+					cfg.SpanOptions.ArgumentOptions.EnableAttributes = tc.enableArgs
 					mc := newMockConn(tc.error)
 					otelConn := newConn(mc, cfg)
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -212,6 +212,7 @@ func TestOtConn_ExecContext(t *testing.T) {
 		error        bool
 		noParentSpan bool
 		disableQuery bool
+		enableArgs   bool
 		attrs        []attribute.KeyValue
 	}{
 		{
@@ -232,6 +233,14 @@ func TestOtConn_ExecContext(t *testing.T) {
 			noParentSpan: true,
 			attrs:        expectedAttrs,
 		},
+		{
+			name:       "enable args as attributes",
+			enableArgs: true,
+			attrs: []attribute.KeyValue{
+				expectedAttrs[0],
+				attribute.String("db.args.1", "foo"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -241,10 +250,11 @@ func TestOtConn_ExecContext(t *testing.T) {
 
 			// New conn
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
+			cfg.ArgumentsOptions.EnableAttributes = tc.enableArgs
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
 
-			_, err := otelConn.ExecContext(ctx, "query", nil)
+			_, err := otelConn.ExecContext(ctx, "query", []driver.NamedValue{{Name: "name", Ordinal: 0, Value: "foo"}})
 			if tc.error {
 				require.Error(t, err)
 			} else {
@@ -286,6 +296,7 @@ func TestOtConn_QueryContext(t *testing.T) {
 				error        bool
 				noParentSpan bool
 				disableQuery bool
+				enableArgs   bool
 				attrs        []attribute.KeyValue
 			}{
 				{
@@ -306,6 +317,14 @@ func TestOtConn_QueryContext(t *testing.T) {
 					noParentSpan: true,
 					attrs:        expectedAttrs,
 				},
+				{
+					name:       "enable args as attributes",
+					enableArgs: true,
+					attrs: []attribute.KeyValue{
+						expectedAttrs[0],
+						attribute.String("db.args.1", "foo"),
+					},
+				},
 			}
 
 			for _, tc := range testCases {
@@ -316,10 +335,11 @@ func TestOtConn_QueryContext(t *testing.T) {
 					// New conn
 					cfg.SpanOptions.DisableQuery = tc.disableQuery
 					cfg.SpanOptions.OmitConnQuery = omitConnQuery
+					cfg.ArgumentsOptions.EnableAttributes = tc.enableArgs
 					mc := newMockConn(tc.error)
 					otelConn := newConn(mc, cfg)
 
-					rows, err := otelConn.QueryContext(ctx, "query", nil)
+					rows, err := otelConn.QueryContext(ctx, "query", []driver.NamedValue{{Name: "name", Ordinal: 0, Value: "foo"}})
 					if tc.error {
 						require.Error(t, err)
 					} else {
@@ -382,6 +402,7 @@ func TestOtConn_PrepareContext(t *testing.T) {
 				error        bool
 				noParentSpan bool
 				disableQuery bool
+				enableArgs   bool
 				attrs        []attribute.KeyValue
 			}{
 				{

--- a/conn_test.go
+++ b/conn_test.go
@@ -164,10 +164,9 @@ func TestOtConn_Ping(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+			ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 
 			// New conn
-			cfg := newMockConfig(t, tracer)
 			cfg.SpanOptions.Ping = tc.pingOption
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
@@ -238,10 +237,9 @@ func TestOtConn_ExecContext(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+			ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 
 			// New conn
-			cfg := newMockConfig(t, tracer)
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
@@ -313,10 +311,9 @@ func TestOtConn_QueryContext(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
 					// Prepare traces
-					ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+					ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 
 					// New conn
-					cfg := newMockConfig(t, tracer)
 					cfg.SpanOptions.DisableQuery = tc.disableQuery
 					cfg.SpanOptions.OmitConnQuery = omitConnQuery
 					mc := newMockConn(tc.error)
@@ -410,10 +407,9 @@ func TestOtConn_PrepareContext(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
 					// Prepare traces
-					ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+					ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 
 					// New conn
-					cfg := newMockConfig(t, tracer)
 					cfg.SpanOptions.DisableQuery = tc.disableQuery
 					cfg.SpanOptions.OmitConnPrepare = omitConnPrepare
 					mc := newMockConn(tc.error)
@@ -477,10 +473,9 @@ func TestOtConn_BeginTx(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+			ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 
 			// New conn
-			cfg := newMockConfig(t, tracer)
 			mc := newMockConn(tc.error)
 			otelConn := newConn(mc, cfg)
 
@@ -548,10 +543,9 @@ func TestOtConn_ResetSession(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
 					// Prepare traces
-					ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+					ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 
 					// New conn
-					cfg := newMockConfig(t, tracer)
 					cfg.SpanOptions.OmitConnResetSession = omitResetSession
 					mc := newMockConn(tc.error)
 					otelConn := newConn(mc, cfg)

--- a/connector.go
+++ b/connector.go
@@ -46,7 +46,7 @@ func (c *otConnector) Connect(ctx context.Context) (connection driver.Conn, err 
 
 	var span trace.Span
 	if !c.cfg.SpanOptions.OmitConnectorConnect {
-		ctx, span = c.cfg.Tracer.Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
+		ctx, span = c.cfg.Tracer().Start(ctx, c.cfg.SpanNameFormatter.Format(ctx, method, ""),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(c.cfg.Attributes...),
 		)

--- a/connector_test.go
+++ b/connector_test.go
@@ -90,9 +90,8 @@ func TestOtConnector_Connect(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
 					// Prepare traces
-					ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+					ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 
-					cfg := newMockConfig(t, tracer)
 					cfg.SpanOptions.OmitConnectorConnect = omitConnectorConnect
 					mConnector := newMockConnector(nil, tc.error)
 					connector := newConnector(mConnector, &otDriver{cfg: cfg})

--- a/option.go
+++ b/option.go
@@ -52,7 +52,7 @@ func WithAttributes(attributes ...attribute.KeyValue) Option {
 
 // WithArgumentsAttributes specifies configurations for span to decide whether to enable
 // some features.
-func WithArgumentsAttributes(opts ArgumentsOptions) Option {
+func WithArgumentsAttributes(opts ArgumentOptions) Option {
 	return OptionFunc(func(cfg *config) {
 		cfg.ArgumentsOptions = opts
 	})

--- a/option.go
+++ b/option.go
@@ -50,14 +50,6 @@ func WithAttributes(attributes ...attribute.KeyValue) Option {
 	})
 }
 
-// WithArgumentsAttributes specifies configurations for span to decide whether to enable
-// some features.
-func WithArgumentsAttributes(opts ArgumentOptions) Option {
-	return OptionFunc(func(cfg *config) {
-		cfg.ArgumentsOptions = opts
-	})
-}
-
 // WithSpanNameFormatter takes an interface that will be called on every
 // operation and the returned string will become the span name.
 func WithSpanNameFormatter(spanNameFormatter SpanNameFormatter) Option {

--- a/option.go
+++ b/option.go
@@ -50,6 +50,14 @@ func WithAttributes(attributes ...attribute.KeyValue) Option {
 	})
 }
 
+// WithArgumentsAttributes specifies configurations for span to decide whether to enable
+// some features.
+func WithArgumentsAttributes(opts ArgumentsOptions) Option {
+	return OptionFunc(func(cfg *config) {
+		cfg.ArgumentsOptions = opts
+	})
+}
+
 // WithSpanNameFormatter takes an interface that will be called on every
 // operation and the returned string will become the span name.
 func WithSpanNameFormatter(spanNameFormatter SpanNameFormatter) Option {

--- a/rows.go
+++ b/rows.go
@@ -46,7 +46,7 @@ func newRows(ctx context.Context, rows driver.Rows, cfg config) *otRows {
 	onClose := recordMetric(ctx, cfg.Instruments, cfg.Attributes, method)
 
 	if !cfg.SpanOptions.OmitRows {
-		_, span = cfg.Tracer.Start(ctx, cfg.SpanNameFormatter.Format(ctx, method, ""),
+		_, span = cfg.Tracer().Start(ctx, cfg.SpanNameFormatter.Format(ctx, method, ""),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(cfg.Attributes...),
 		)

--- a/rows_test.go
+++ b/rows_test.go
@@ -76,10 +76,9 @@ func TestOtRows_Close(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, _ := prepareTraces(false)
+			ctx, cfg, sr, _ := prepareTraces(t, false)
 
 			mr := newMockRows(tc.error)
-			cfg := newMockConfig(t, tracer)
 
 			// New rows
 			rows := newRows(ctx, mr, cfg)
@@ -127,10 +126,9 @@ func TestOtRows_Next(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, _ := prepareTraces(false)
+			ctx, cfg, sr, _ := prepareTraces(t, false)
 
 			mr := newMockRows(tc.error)
-			cfg := newMockConfig(t, tracer)
 			cfg.SpanOptions.RowsNext = tc.rowsNextOption
 
 			// New rows
@@ -188,10 +186,9 @@ func TestNewRows(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
 					// Prepare traces
-					ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+					ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 
 					mr := newMockRows(false)
-					cfg := newMockConfig(t, tracer)
 					cfg.SpanOptions.OmitRows = omitRows
 
 					// New rows

--- a/stmt.go
+++ b/stmt.go
@@ -56,7 +56,7 @@ func (s *otStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res
 	}()
 
 	var span trace.Span
-	ctx, span = s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
+	ctx, span = s.cfg.Tracer().Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
 	)
@@ -82,7 +82,7 @@ func (s *otStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (ro
 		onDefer(err)
 	}()
 
-	queryCtx, span := s.cfg.Tracer.Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
+	queryCtx, span := s.cfg.Tracer().Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
 	)

--- a/stmt.go
+++ b/stmt.go
@@ -58,7 +58,7 @@ func (s *otStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res
 	var span trace.Span
 	ctx, span = s.cfg.Tracer().Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(withDBStatement(s.cfg, s.query, args)...),
+		trace.WithAttributes(withDBStatement(ctx, s.cfg, s.query, args)...),
 	)
 	defer span.End()
 
@@ -84,7 +84,7 @@ func (s *otStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (ro
 
 	queryCtx, span := s.cfg.Tracer().Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(withDBStatement(s.cfg, s.query, args)...),
+		trace.WithAttributes(withDBStatement(ctx, s.cfg, s.query, args)...),
 	)
 	defer span.End()
 

--- a/stmt.go
+++ b/stmt.go
@@ -58,7 +58,7 @@ func (s *otStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res
 	var span trace.Span
 	ctx, span = s.cfg.Tracer().Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
+		trace.WithAttributes(withDBStatement(s.cfg, s.query, args)...),
 	)
 	defer span.End()
 
@@ -84,7 +84,7 @@ func (s *otStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (ro
 
 	queryCtx, span := s.cfg.Tracer().Start(ctx, s.cfg.SpanNameFormatter.Format(ctx, method, s.query),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(withDBStatement(s.cfg, s.query)...),
+		trace.WithAttributes(withDBStatement(s.cfg, s.query, args)...),
 	)
 	defer span.End()
 

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -105,11 +105,10 @@ func TestOtStmt_ExecContext(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+			ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 			ms := newMockStmt(tc.error)
 
 			// New stmt
-			cfg := newMockConfig(t, tracer)
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
 			stmt := newStmt(ms, cfg, "query")
 			// Exec
@@ -171,11 +170,10 @@ func TestOtStmt_QueryContext(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+			ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 			ms := newMockStmt(tc.error)
 
 			// New stmt
-			cfg := newMockConfig(t, tracer)
 			cfg.SpanOptions.DisableQuery = tc.disableQuery
 			stmt := newStmt(ms, cfg, "query")
 			// Query

--- a/tx.go
+++ b/tx.go
@@ -45,7 +45,7 @@ func (t *otTx) Commit() (err error) {
 	}()
 
 	var span trace.Span
-	_, span = t.cfg.Tracer.Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, method, ""),
+	_, span = t.cfg.Tracer().Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, method, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(t.cfg.Attributes...),
 	)
@@ -67,7 +67,7 @@ func (t *otTx) Rollback() (err error) {
 	}()
 
 	var span trace.Span
-	_, span = t.cfg.Tracer.Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, method, ""),
+	_, span = t.cfg.Tracer().Start(t.ctx, t.cfg.SpanNameFormatter.Format(t.ctx, method, ""),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(t.cfg.Attributes...),
 	)

--- a/tx_test.go
+++ b/tx_test.go
@@ -77,11 +77,10 @@ func TestOtTx_Commit(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+			ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 			mt := newMockTx(tc.error)
 
 			// New tx
-			cfg := newMockConfig(t, tracer)
 			tx := newTx(ctx, mt, cfg)
 			// Commit
 			err := tx.Commit()
@@ -131,11 +130,10 @@ func TestOtTx_Rollback(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare traces
-			ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+			ctx, cfg, sr, dummySpan := prepareTraces(t, tc.noParentSpan)
 			mt := newMockTx(tc.error)
 
 			// New tx
-			cfg := newMockConfig(t, tracer)
 			tx := newTx(ctx, mt, cfg)
 
 			// Rollback

--- a/utils_test.go
+++ b/utils_test.go
@@ -136,7 +136,7 @@ func newMockConfig(t *testing.T, tracer trace.Tracer) config {
 	require.NoError(t, err)
 
 	return config{
-		Tracer:            tracer,
+		Tracer:            func() trace.Tracer { return tracer },
 		Meter:             meter,
 		Instruments:       instruments,
 		Attributes:        []attribute.KeyValue{defaultattribute},

--- a/utils_test.go
+++ b/utils_test.go
@@ -128,7 +128,7 @@ func createDummySpan(ctx context.Context, tracer trace.Tracer) (context.Context,
 	return ctx, span
 }
 
-func newMockConfig(t *testing.T, tracer trace.Tracer) config {
+func newMockConfig(t *testing.T, tp trace.TracerProvider) config {
 	// TODO: use mock meter instead of noop meter
 	meter := metric.NewNoopMeterProvider().Meter("test")
 
@@ -136,7 +136,7 @@ func newMockConfig(t *testing.T, tracer trace.Tracer) config {
 	require.NoError(t, err)
 
 	return config{
-		Tracer:            func() trace.Tracer { return tracer },
+		TracerProvider:    tp,
 		Meter:             meter,
 		Instruments:       instruments,
 		Attributes:        []attribute.KeyValue{defaultattribute},
@@ -205,14 +205,14 @@ func getExpectedSpanCount(noParentSpan bool, omitSpan bool) int {
 	return 0
 }
 
-func prepareTraces(noParentSpan bool) (context.Context, *tracetest.SpanRecorder, trace.Tracer, trace.Span) {
+func prepareTraces(t *testing.T, noParentSpan bool) (context.Context, config, *tracetest.SpanRecorder, trace.Span) {
 	sr, provider := newTracerProvider()
-	tracer := provider.Tracer("test")
+	cfg := newMockConfig(t, provider)
 
 	var dummySpan trace.Span
 	ctx := context.Background()
 	if !noParentSpan {
-		ctx, dummySpan = createDummySpan(context.Background(), tracer)
+		ctx, dummySpan = createDummySpan(context.Background(), cfg.Tracer())
 	}
-	return ctx, sr, tracer, dummySpan
+	return ctx, cfg, sr, dummySpan
 }


### PR DESCRIPTION
Hi @XSAM, 

This is a follow-up to https://github.com/XSAM/otelsql/pull/115, though were you not interested in merging it, I'll be happy to untangle the git history from those other changes. 

This introduces an additional configuration option that enables to tag the SQL queries with their values, so anyone looking at the traces can also see the values. 

Here is a screenshot of what it looks like: (see `db.args.$1`) 

![image](https://user-images.githubusercontent.com/10151/188410807-662a66a1-7387-4ba0-ace7-d292ff5168cf.png)

If that's good for you, I'll also update the README 🙏 

--- 

_Requires #115 to be merged first, albeit the changes are not really related, but as we did it this way, I'd rather check with you before reworking the PR if that's really needed._ 