### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.17.0] - 2022-10-21
+
 ### ⚠️ Notice ⚠️
 
 The minimum supported Go version is `1.18`.
@@ -199,7 +201,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/XSAM/otelsql/releases/tag/v0.17.0
 [0.16.0]: https://github.com/XSAM/otelsql/releases/tag/v0.16.0
 [0.15.0]: https://github.com/XSAM/otelsql/releases/tag/v0.15.0
 [0.14.1]: https://github.com/XSAM/otelsql/releases/tag/v0.14.1

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.16.0"
+	return "0.17.0"
 }


### PR DESCRIPTION
## 0.17.0 - 2022-10-21

### ⚠️ Notice ⚠️

The minimum supported Go version is `1.18`.

### Added

- Go 1.19 to supported versions. (#118)
- `WithAttributesGetter` option provides additional attributes on spans creation. (#125)

### Changed

- Upgrade OTel to version `1.10.0`. (#119)
- Upgrade OTel to version `1.11.0/0.32.3`. (#122)
- Upgrade OTel to version `1.11.1/0.33.0`. (#126)

  This OTel release contains a feature that the `go.opentelemetry.io/otel/exporters/prometheus` exporter now adds a unit suffix to metric names. This can be disabled using the `WithoutUnits()` option added to that package.

### Removed

- Support for Go `1.17`. Support is now only for Go `1.18` and Go `1.19`. (#123)