### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.18.0] - 2023-02-01
+
 ### Changed
 
 - Upgrade OTel to version `1.12.0/0.35.0`. (#139)
@@ -212,7 +214,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/XSAM/otelsql/releases/tag/v0.18.0
 [0.17.1]: https://github.com/XSAM/otelsql/releases/tag/v0.17.1
 [0.17.0]: https://github.com/XSAM/otelsql/releases/tag/v0.17.0
 [0.16.0]: https://github.com/XSAM/otelsql/releases/tag/v0.16.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.17.1"
+	return "0.18.0"
 }


### PR DESCRIPTION
## 0.18.0 - 2023-02-01

### Changed

- Upgrade OTel to version `1.12.0/0.35.0`. (#139)
- Upgrade all `semconv` packages to use `v1.17.0`. (#141)