### PR TITLE
Release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.19.0] - 2023-02-13
+
 ### Added
 
 - Go 1.20 to supported versions. (#146)
@@ -222,7 +224,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/XSAM/otelsql/releases/tag/v0.19.0
 [0.18.0]: https://github.com/XSAM/otelsql/releases/tag/v0.18.0
 [0.17.1]: https://github.com/XSAM/otelsql/releases/tag/v0.17.1
 [0.17.0]: https://github.com/XSAM/otelsql/releases/tag/v0.17.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.18.0"
+	return "0.19.0"
 }


### PR DESCRIPTION
## 0.19.0 - 2023-02-13

### Added

- Go 1.20 to supported versions. (#146)

### Changed

- Upgrade OTel to version `1.13.0/0.36.0`. (#145)