### PR TITLE
Adds SpanFilter as a configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `SpanFilter` configuration in `SpanOptions` to filter spans creation. (#174)
+
 ## [0.23.0] - 2023-05-22
 
 ### Changed

--- a/config.go
+++ b/config.go
@@ -43,6 +43,8 @@ type SpanNameFormatter interface {
 // AttributesGetter provides additional attributes on spans creation.
 type AttributesGetter func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue
 
+type SpanFilter func(ctx context.Context, method Method, query string, args []driver.NamedValue) bool
+
 type config struct {
 	TracerProvider trace.TracerProvider
 	Tracer         trace.Tracer
@@ -116,6 +118,10 @@ type SpanOptions struct {
 
 	// OmitConnectorConnect if set to true will suppress sql.connector.connect spans
 	OmitConnectorConnect bool
+
+	// SpanFilter, if set, will be invoked before each call to create a span. If it returns
+	// false, the span will not be created.
+	SpanFilter SpanFilter
 }
 
 type defaultSpanNameFormatter struct{}

--- a/connector.go
+++ b/connector.go
@@ -45,7 +45,7 @@ func (c *otConnector) Connect(ctx context.Context) (connection driver.Conn, err 
 	}()
 
 	var span trace.Span
-	if !c.cfg.SpanOptions.OmitConnectorConnect {
+	if !c.cfg.SpanOptions.OmitConnectorConnect && filterSpan(ctx, c.cfg.SpanOptions, method, "", nil) {
 		ctx, span = createSpan(ctx, c.cfg, method, false, "", nil)
 		defer span.End()
 	}

--- a/driver.go
+++ b/driver.go
@@ -14,9 +14,7 @@
 
 package otelsql
 
-import (
-	"database/sql/driver"
-)
+import "database/sql/driver"
 
 var (
 	_ driver.Driver        = (*otDriver)(nil)

--- a/rows.go
+++ b/rows.go
@@ -45,7 +45,7 @@ func newRows(ctx context.Context, rows driver.Rows, cfg config) *otRows {
 	method := MethodRows
 	onClose := recordMetric(ctx, cfg.Instruments, cfg.Attributes, method)
 
-	if !cfg.SpanOptions.OmitRows {
+	if !cfg.SpanOptions.OmitRows && filterSpan(ctx, cfg.SpanOptions, method, "", nil) {
 		_, span = createSpan(ctx, cfg, method, false, "", nil)
 	}
 

--- a/sql.go
+++ b/sql.go
@@ -135,7 +135,9 @@ func RegisterDBStatsMetrics(db *sql.DB, opts ...Option) error {
 	return nil
 }
 
-func recordDBStatsMetrics(dbStats sql.DBStats, instruments *dbStatsInstruments, cfg config, observer metric.Observer) {
+func recordDBStatsMetrics(
+	dbStats sql.DBStats, instruments *dbStatsInstruments, cfg config, observer metric.Observer,
+) {
 	observer.ObserveInt64(instruments.connectionMaxOpen,
 		int64(dbStats.MaxOpenConnections),
 		metric.WithAttributes(cfg.Attributes...),

--- a/tx.go
+++ b/tx.go
@@ -45,8 +45,10 @@ func (t *otTx) Commit() (err error) {
 	}()
 
 	var span trace.Span
-	_, span = createSpan(t.ctx, t.cfg, method, false, "", nil)
-	defer span.End()
+	if filterSpan(t.ctx, t.cfg.SpanOptions, method, "", nil) {
+		_, span = createSpan(t.ctx, t.cfg, method, false, "", nil)
+		defer span.End()
+	}
 
 	err = t.tx.Commit()
 	if err != nil {
@@ -64,8 +66,10 @@ func (t *otTx) Rollback() (err error) {
 	}()
 
 	var span trace.Span
-	_, span = createSpan(t.ctx, t.cfg, method, false, "", nil)
-	defer span.End()
+	if filterSpan(t.ctx, t.cfg.SpanOptions, method, "", nil) {
+		_, span = createSpan(t.ctx, t.cfg, method, false, "", nil)
+		defer span.End()
+	}
 
 	err = t.tx.Rollback()
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -53,7 +53,12 @@ func recordSpanError(span trace.Span, opts SpanOptions, err error) {
 	}
 }
 
-func recordMetric(ctx context.Context, instruments *instruments, defaultAttributes []attribute.KeyValue, method Method) func(error) {
+func recordMetric(
+	ctx context.Context,
+	instruments *instruments,
+	defaultAttributes []attribute.KeyValue,
+	method Method,
+) func(error) {
 	startTime := time.Now()
 
 	return func(err error) {
@@ -76,7 +81,14 @@ func recordMetric(ctx context.Context, instruments *instruments, defaultAttribut
 	}
 }
 
-func createSpan(ctx context.Context, cfg config, method Method, enableDBStatement bool, query string, args []driver.NamedValue) (context.Context, trace.Span) {
+func createSpan(
+	ctx context.Context,
+	cfg config,
+	method Method,
+	enableDBStatement bool,
+	query string,
+	args []driver.NamedValue,
+) (context.Context, trace.Span) {
 	attrs := cfg.Attributes
 	if enableDBStatement && !cfg.SpanOptions.DisableQuery {
 		attrs = append(attrs, semconv.DBStatementKey.String(query))
@@ -89,6 +101,16 @@ func createSpan(ctx context.Context, cfg config, method Method, enableDBStatemen
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(attrs...),
 	)
+}
+
+func filterSpan(
+	ctx context.Context,
+	spanOptions SpanOptions,
+	method Method,
+	query string,
+	args []driver.NamedValue,
+) bool {
+	return spanOptions.SpanFilter == nil || spanOptions.SpanFilter(ctx, method, query, args)
 }
 
 // Copied from stdlib database/sql package: src/database/sql/ctxutil.go.

--- a/utils_test.go
+++ b/utils_test.go
@@ -160,7 +160,9 @@ type spanAssertionParameter struct {
 	args               []driver.NamedValue
 }
 
-func assertSpanList(t *testing.T, spanList []sdktrace.ReadOnlySpan, parameter spanAssertionParameter) {
+func assertSpanList(
+	t *testing.T, spanList []sdktrace.ReadOnlySpan, parameter spanAssertionParameter,
+) {
 	var span sdktrace.ReadOnlySpan
 	if !parameter.omitSpan {
 		if !parameter.noParentSpan {
@@ -215,7 +217,9 @@ func getExpectedSpanCount(noParentSpan bool, omitSpan bool) int {
 	return 0
 }
 
-func prepareTraces(noParentSpan bool) (context.Context, *tracetest.SpanRecorder, trace.Tracer, trace.Span) {
+func prepareTraces(
+	noParentSpan bool,
+) (context.Context, *tracetest.SpanRecorder, trace.Tracer, trace.Span) {
 	sr, provider := newTracerProvider()
 	tracer := provider.Tracer("test")
 
@@ -242,4 +246,14 @@ func getDummyAttributesGetter() AttributesGetter {
 
 		return attrs
 	}
+}
+
+// omit is a dummy SpanFilter function which specifies to omit the span.
+var omit SpanFilter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) bool {
+	return false
+}
+
+// keep is a dummy SpanFilter function which specifies to keep the span.
+var keep SpanFilter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) bool {
+	return true
 }


### PR DESCRIPTION
SpanFilter is a custom function that can be passed via configuration to control whether any given span should be included or omitted. (#169)

Example usage:

```go
otelsql.SpanOptions{
    // Skip creating spans which don't have a parent
    SpanFilter: func(ctx context.Context, method otelsql.Method, query string, args []driver.NamedValue) bool {
        span := trace.SpanFromContext(ctx)
        return span.SpanContext().IsValid()
    },
}
```