### PR TITLE
Release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.24.0] - 2023-09-08
+
 ### Added
 
 - `SpanFilter` configuration in `SpanOptions` to filter spans creation. (#174)
@@ -273,7 +275,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/XSAM/otelsql/releases/tag/v0.24.0
 [0.23.0]: https://github.com/XSAM/otelsql/releases/tag/v0.23.0
 [0.22.0]: https://github.com/XSAM/otelsql/releases/tag/v0.22.0
 [0.21.0]: https://github.com/XSAM/otelsql/releases/tag/v0.21.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.23.0"
+	return "0.24.0"
 }


### PR DESCRIPTION
## 0.24.0 - 2023-09-08

### Added

- `SpanFilter` configuration in `SpanOptions` to filter spans creation. (#174)
- Go 1.21 to supported versions. (#180)

### Changed

- Upgrade OTel to version `v1.17.0/v0.40.0`. (#181)