### PR TITLE
Release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.25.0] - 2023-09-18
+
 ### ⚠️ Notice ⚠️
 
 This update contains a breaking change of the type of `SpanNameFormatter`. If you use `SpanNameFormatter` in your code, you need to change the type of `SpanNameFormatter` to function.
@@ -290,7 +292,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/XSAM/otelsql/releases/tag/v0.25.0
 [0.24.0]: https://github.com/XSAM/otelsql/releases/tag/v0.24.0
 [0.23.0]: https://github.com/XSAM/otelsql/releases/tag/v0.23.0
 [0.22.0]: https://github.com/XSAM/otelsql/releases/tag/v0.22.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.24.0"
+	return "0.25.0"
 }


### PR DESCRIPTION
## 0.25.0 - 2023-09-18

### ⚠️ Notice ⚠️

This update contains a breaking change of the type of `SpanNameFormatter`. If you use `SpanNameFormatter` in your code, you need to change the type of `SpanNameFormatter` to function.

The minimum supported Go version is `1.20`.

### Changed

- Upgrade OTel to version `v1.18.0/v0.41.0`. (#184)
- The type of `SpanNameFormatter` has been changed to function for easier use. (#185)

### Removed

- Support for Go `1.19`. (#186)