### PR TITLE
Fix io.Closer support for connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Upgrade OTel to version `v1.20.0/v0.43.0`. (#196)
+- Fixes an issue where `db.Close` did not call `Close` on the underlying connector. (#199)
 
 ## [0.26.0] - 2023-10-11
 

--- a/connector.go
+++ b/connector.go
@@ -23,7 +23,6 @@ import (
 )
 
 var _ driver.Connector = (*otConnector)(nil)
-
 var _ io.Closer = (*otConnector)(nil)
 
 type otConnector struct {

--- a/connector.go
+++ b/connector.go
@@ -24,6 +24,8 @@ import (
 
 var _ driver.Connector = (*otConnector)(nil)
 
+var _ io.Closer = (*otConnector)(nil)
+
 type otConnector struct {
 	driver.Connector
 	otDriver *otDriver


### PR DESCRIPTION
It appears that closing a DB using `XSAM/otelsql` does not always propagate to the underlying driver. That's apparently due to `io.Closer` being optional for connectors and `database/sql` using a type assertion to check whether the connector implements it. That type assertion does not pass through to `otConnector.Connector`, so we need to explicitly implement `Close() error` on `otConnector` and replicate the type assertion there.
