### PR TITLE
Release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.29.0] - 2024-02-26
+
 ### Changed
 
 - Upgrade OTel to version `v1.24.0/v0.46.0`. (#218)
@@ -320,7 +322,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.28.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/XSAM/otelsql/releases/tag/v0.29.0
 [0.28.0]: https://github.com/XSAM/otelsql/releases/tag/v0.28.0
 [0.27.0]: https://github.com/XSAM/otelsql/releases/tag/v0.27.0
 [0.26.0]: https://github.com/XSAM/otelsql/releases/tag/v0.26.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.28.0"
+	return "0.29.0"
 }


### PR DESCRIPTION
## 0.29.0 - 2024-02-26

### Changed

- Upgrade OTel to version `v1.24.0/v0.46.0`. (#218)