### PR TITLE
Fallback NamedValueChecker from Stmt to Conn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Fallback the check of `driver.NamedValueChecker` from Stmt to Conn. (#243)
+  So, the `otelsql` can keep the original check order in `database/sql` for value checkers in the following order,
+  stopping at the first found match: `Stmt.NamedValueChecker`, `Conn.NamedValueChecker`.
+
 ## [0.30.0] - 2024-04-15
 
 ### ⚠️ Notice ⚠️

--- a/conn.go
+++ b/conn.go
@@ -184,7 +184,7 @@ func (c *otConn) PrepareContext(ctx context.Context, query string) (stmt driver.
 		}
 	}
 
-	return newStmt(stmt, c.cfg, query), nil
+	return newStmt(stmt, c.cfg, query, c), nil
 }
 
 func (c *otConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.Tx, err error) {

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -337,7 +337,7 @@ func TestOtStmt_QueryContext(t *testing.T) {
 
 type namedValueChecker struct{ err error }
 
-func (nvc *namedValueChecker) CheckNamedValue(nv *driver.NamedValue) error {
+func (nvc *namedValueChecker) CheckNamedValue(_ *driver.NamedValue) error {
 	return nvc.err
 }
 


### PR DESCRIPTION
> The [database/sql] package checks for value checkers in the following order,
> stopping at the first found match: Stmt.NamedValueChecker, Conn.NamedValueChecker,
> Stmt.ColumnConverter, [DefaultParameterConverter].

Since otelsql implements the `NamedValueChecker` for both Stmt and Conn, the fallback logic in the Go is not working.
Source: https://go.googlesource.com/go/+/refs/tags/go1.22.2/src/database/sql/convert.go#128

This is a workaround to make sure the named value checker is checked on the connection level after
the statement level.

---

This also resolves #117