### PR TITLE
Release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.31.0] - 2024-05-02
+
 ### Changed
 
 - Fallback the check of `driver.NamedValueChecker` from Stmt to Conn. (#243)
@@ -343,7 +345,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.30.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.31.0...HEAD
+[0.31.0]: https://github.com/XSAM/otelsql/releases/tag/v0.31.0
 [0.30.0]: https://github.com/XSAM/otelsql/releases/tag/v0.30.0
 [0.29.0]: https://github.com/XSAM/otelsql/releases/tag/v0.29.0
 [0.28.0]: https://github.com/XSAM/otelsql/releases/tag/v0.28.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.30.0"
+	return "0.31.0"
 }


### PR DESCRIPTION
## 0.31.0 - 2024-05-02

### Changed

- Fallback the check of `driver.NamedValueChecker` from Stmt to Conn. (#243)
  So, the `otelsql` can keep the original check order in `database/sql` for value checkers in the following order,
  stopping at the first found match: `Stmt.NamedValueChecker`, `Conn.NamedValueChecker`.
- Upgrade OTel to version `v1.26.0/v0.48.0`. (#244)