### PR TITLE
Fix docker compose warning regarding the version field

### DIFF
--- a/example/otel-collector/docker-compose.yaml
+++ b/example/otel-collector/docker-compose.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version: "3.9"
 services:
   mysql:
     image: mysql:8.4

--- a/example/stdout/docker-compose.yml
+++ b/example/stdout/docker-compose.yml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version: "3.9"
 services:
   mysql:
     image: mysql:8.4


### PR DESCRIPTION
Fix this warning:

```
WARN[0000] otelsql/example/otel-collector/docker-compose.yaml: `version` is obsolete
```