### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "ignorePaths": [],
+  "postUpdateOptions" : [
+    "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    },
+    {
+      "matchFileNames": ["internal/tools/**"],
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Changes:

- Include all paths to prevent accidentally ignoring some paths.

    The real default: https://docs.renovatebot.com/presets-default/#ignoremodulesandtests because of https://docs.renovatebot.com/presets-config/#configrecommended
    
    This default config includes `**/examples/**`, which might ignore the `example` folder if I changed the folder name to `examples`.

- Update indirect dependencies to reduce the chance of a diamond dependency problem. However, this rule ignores the internal tool as it is not necessary.