### PR TITLE
Release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.33.0] - 2024-08-27
+
 ### Added
 
 - `WithInstrumentAttributesGetter` option provides additional attributes when `latency` histogram is recorded. (#334)
+
+### Changed
+
+- Upgrade OTel to version `v1.29.0/v0.51.0`. (#336)
 
 ## [0.32.0] - 2024-07-05
 
 ### Changed
 
-- ~~Upgrade OTel to version `v1.28.0/v0.50.0`. (#310)~~
-- Upgrade OTel to version `v1.29.0/v0.51.0`. (#336)
+- Upgrade OTel to version `v1.28.0/v0.50.0`. (#310)
 
 ## [0.31.0] - 2024-05-02
 
@@ -356,7 +361,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.32.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/XSAM/otelsql/releases/tag/v0.33.0
 [0.32.0]: https://github.com/XSAM/otelsql/releases/tag/v0.32.0
 [0.31.0]: https://github.com/XSAM/otelsql/releases/tag/v0.31.0
 [0.30.0]: https://github.com/XSAM/otelsql/releases/tag/v0.30.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.32.0"
+	return "0.33.0"
 }


### PR DESCRIPTION
## 0.33.0 - 2024-08-27

### Added

- `WithInstrumentAttributesGetter` option provides additional attributes when `latency` histogram is recorded. (#334)

### Changed

- Upgrade OTel to version `v1.29.0/v0.51.0`. (#336)