### PR TITLE
Release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.34.0] - 2024-09-14
+
 The minimum supported Go version is `1.22`.
 
 ### Added
@@ -379,7 +381,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.33.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.34.0...HEAD
+[0.34.0]: https://github.com/XSAM/otelsql/releases/tag/v0.34.0
 [0.33.0]: https://github.com/XSAM/otelsql/releases/tag/v0.33.0
 [0.32.0]: https://github.com/XSAM/otelsql/releases/tag/v0.32.0
 [0.31.0]: https://github.com/XSAM/otelsql/releases/tag/v0.31.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.33.0"
+	return "0.34.0"
 }


### PR DESCRIPTION
The minimum supported Go version is `1.22`.

### Added

- Go 1.23 to supported versions. (#361)

### Changed

- The `Open` method uses the `dataSourceName` when calling `sql.Open`. (#359)

  This change improves compatibility with certain drivers that perform a verification of the `dataSourceName` before establishing a connection.
- Upgrade OTel to version `v1.30.0/v0.52.0`. (#356)

### Removed

- Support for Go `1.21`. (#356)