### PR TITLE
Update comment of `WithAttributes` and config `Attributes`

### DIFF
--- a/config.go
+++ b/config.go
@@ -56,7 +56,7 @@ type config struct {
 
 	SpanOptions SpanOptions
 
-	// Attributes will be set to each span.
+	// Attributes will be set to each span and measurement.
 	Attributes []attribute.KeyValue
 
 	// SpanNameFormatter will be called to produce span's name.

--- a/option.go
+++ b/option.go
@@ -43,7 +43,7 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 	})
 }
 
-// WithAttributes specifies attributes that will be set to each span.
+// WithAttributes specifies attributes that will be set to each span and measurement.
 func WithAttributes(attributes ...attribute.KeyValue) Option {
 	return OptionFunc(func(cfg *config) {
 		cfg.Attributes = attributes


### PR DESCRIPTION
 This change reflects the correct behavior when creating measurements.