### PR TITLE
Add AttributesFromDSN method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `AttributesFromDSN` method to generate `server.address` and `server.port` attributes from a DSN. (#419)
+
 ### Changed
 
 - Upgrade OTel to `v1.34.0/v0.56.0`. (#412)

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -162,9 +162,11 @@ func main() {
 }
 
 func connectDB() *sql.DB {
+	attrs := append(otelsql.AttributesFromDSN(mysqlDSN), semconv.DBSystemMySQL)
+
 	// Connect to database
 	db, err := otelsql.Open("mysql", mysqlDSN, otelsql.WithAttributes(
-		semconv.DBSystemMySQL,
+		attrs...,
 	))
 	if err != nil {
 		log.Fatal(err)
@@ -172,7 +174,7 @@ func connectDB() *sql.DB {
 
 	// Register DB stats to meter
 	err = otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(
-		semconv.DBSystemMySQL,
+		attrs...,
 	))
 	if err != nil {
 		log.Fatal(err)

--- a/example/stdout/main.go
+++ b/example/stdout/main.go
@@ -86,9 +86,11 @@ func main() {
 	initTracer()
 	initMeter()
 
+	attrs := append(otelsql.AttributesFromDSN(mysqlDSN), semconv.DBSystemMySQL)
+
 	// Connect to database
 	db, err := otelsql.Open("mysql", mysqlDSN, otelsql.WithAttributes(
-		semconv.DBSystemMySQL,
+		attrs...,
 	))
 	if err != nil {
 		panic(err)
@@ -96,7 +98,7 @@ func main() {
 	defer db.Close()
 
 	err = otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(
-		semconv.DBSystemMySQL,
+		attrs...,
 	))
 	if err != nil {
 		panic(err)

--- a/example_test.go
+++ b/example_test.go
@@ -18,6 +18,8 @@ import (
 	"database/sql"
 	"database/sql/driver"
 
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+
 	"github.com/XSAM/otelsql"
 )
 
@@ -74,5 +76,27 @@ func ExampleRegister() {
 		panic(err)
 	}
 	defer db.Close()
+	// Output:
+}
+
+func ExampleAttributesFromDSN() {
+	attrs := append(otelsql.AttributesFromDSN(mysqlDSN), semconv.DBSystemMySQL)
+
+	// Connect to database
+	db, err := otelsql.Open("mysql", mysqlDSN, otelsql.WithAttributes(
+		attrs...,
+	))
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	// Register DB stats to meter
+	err = otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(
+		attrs...,
+	))
+	if err != nil {
+		panic(err)
+	}
 	// Output:
 }

--- a/helpers.go
+++ b/helpers.go
@@ -75,7 +75,7 @@ func AttributesFromDSN(dsn string) []attribute.KeyValue {
 	if portStr != "" {
 		port, err := strconv.ParseInt(portStr, 10, 64)
 		if err == nil {
-			attrs = append(attrs, semconv.ServerPort(int(port)))
+			attrs = append(attrs, semconv.ServerPortKey.Int64(port))
 		}
 	}
 

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,83 @@
+// Copyright Sam Xie
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsql
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+)
+
+// AttributesFromDSN returns attributes extracted from a DSN string.
+// It makes the best effort to retrieve values for [semconv.ServerAddressKey] and [semconv.ServerPortKey].
+func AttributesFromDSN(dsn string) []attribute.KeyValue {
+	// [scheme://][user[:password]@][protocol([addr])]/dbname[?param1=value1&paramN=valueN]
+	// Find the schema part.
+	schemaIndex := strings.Index(dsn, "://")
+	if schemaIndex != -1 {
+		// Remove the schema part from the DSN.
+		dsn = dsn[schemaIndex+3:]
+	}
+
+	// [user[:password]@][protocol([addr])]/dbname[?param1=value1&paramN=valueN]
+	// Find credentials part.
+	atIndex := strings.Index(dsn, "@")
+	if atIndex != -1 {
+		// Remove the credential part from the DSN.
+		dsn = dsn[atIndex+1:]
+	}
+
+	// [protocol([addr])]/dbname[?param1=value1&paramN=valueN]
+	// Find the '/' that separates the address part from the database part.
+	pathIndex := strings.Index(dsn, "/")
+	if pathIndex != -1 {
+		// Remove the path part from the DSN.
+		dsn = dsn[:pathIndex]
+	}
+
+	// [protocol([addr])] or [addr]
+	// Find the '(' that starts the address part.
+	openParen := strings.Index(dsn, "(")
+	if openParen != -1 {
+		// Remove the protocol part from the DSN.
+		dsn = dsn[openParen+1 : len(dsn)-1]
+	}
+
+	// [addr]
+	if len(dsn) == 0 {
+		return nil
+	}
+	host, portStr, err := net.SplitHostPort(dsn)
+	if err != nil {
+		host = dsn
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if host != "" {
+		attrs = append(attrs, semconv.ServerAddress(host))
+	}
+
+	if portStr != "" {
+		port, err := strconv.ParseInt(portStr, 10, 64)
+		if err == nil {
+			attrs = append(attrs, semconv.ServerPort(int(port)))
+		}
+	}
+
+	return attrs
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,147 @@
+// Copyright Sam Xie
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+)
+
+func TestAttributesFromDSN(t *testing.T) {
+	testCases := []struct {
+		dsn      string
+		expected []attribute.KeyValue
+	}{
+		{
+			dsn: "mysql://root:otel_password@tcp(example.com)/db?parseTime=true",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+			},
+		},
+		{
+			dsn: "mysql://root:otel_password@tcp(example.com:3307)/db?parseTime=true",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+				semconv.ServerPort(3307),
+			},
+		},
+		{
+			dsn: "mysql://root:otel_password@tcp([2001:db8:1234:5678:9abc:def0:0001]:3307)/db?parseTime=true",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("2001:db8:1234:5678:9abc:def0:0001"),
+				semconv.ServerPort(3307),
+			},
+		},
+		{
+			dsn: "mysql://root:otel_password@tcp(2001:db8:1234:5678:9abc:def0:0001)/db?parseTime=true",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("2001:db8:1234:5678:9abc:def0:0001"),
+			},
+		},
+		{
+			dsn: "root:secret@tcp(mysql)/db?parseTime=true",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("mysql"),
+			},
+		},
+		{
+			dsn: "root:secret@tcp(mysql:3307)/db?parseTime=true",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("mysql"),
+				semconv.ServerPort(3307),
+			},
+		},
+		{
+			dsn:      "root:secret@/db?parseTime=true",
+			expected: nil,
+		},
+		{
+			dsn: "example.com/db?parseTime=true",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+			},
+		},
+		{
+			dsn: "example.com:3307/db?parseTime=true",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+				semconv.ServerPort(3307),
+			},
+		},
+		{
+			dsn: "example.com:3307",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+				semconv.ServerPort(3307),
+			},
+		},
+		{
+			dsn: "example.com:",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+			},
+		},
+		{
+			dsn: "example.com",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+			},
+		},
+		{
+			dsn: "postgres://root:secret@0.0.0.0:42/db?param1=value1&paramN=valueN",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("0.0.0.0"),
+				semconv.ServerPort(42),
+			},
+		},
+		{
+			dsn: "postgres://root:secret@2001:db8:1234:5678:9abc:def0:0001/db?param1=value1&paramN=valueN",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("2001:db8:1234:5678:9abc:def0:0001"),
+			},
+		},
+		{
+			dsn: "postgres://root:secret@[2001:db8:1234:5678:9abc:def0:0001]:42/db?param1=value1&paramN=valueN",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("2001:db8:1234:5678:9abc:def0:0001"),
+				semconv.ServerPort(42),
+			},
+		},
+		{
+			dsn: "root:secret@0.0.0.0:42/db?param1=value1&paramN=valueN",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("0.0.0.0"),
+				semconv.ServerPort(42),
+			},
+		},
+		{
+			// In this case, "tcp" will be considered as the server address.
+			dsn: "root:secret@tcp/db?param1=value1&paramN=valueN",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("tcp"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.dsn, func(t *testing.T) {
+			got := AttributesFromDSN(tc.dsn)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Part of #399.

This method makes the best effort to retrieve values for `server.address` and `server.port` attributes from DSN.