### PR TITLE
Release v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.37.0] - 2025-02-16
+
 ### Added
 
 - `AttributesFromDSN` method to generate `server.address` and `server.port` attributes from a DSN. (#419)
@@ -408,7 +410,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.36.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.37.0...HEAD
+[0.37.0]: https://github.com/XSAM/otelsql/releases/tag/v0.37.0
 [0.36.0]: https://github.com/XSAM/otelsql/releases/tag/v0.36.0
 [0.35.0]: https://github.com/XSAM/otelsql/releases/tag/v0.35.0
 [0.34.0]: https://github.com/XSAM/otelsql/releases/tag/v0.34.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.36.0"
+	return "0.37.0"
 }


### PR DESCRIPTION
### Added

- `AttributesFromDSN` method to generate `server.address` and `server.port` attributes from a DSN. (#419)
- Go 1.24 to supported versions. (#422)

### Changed

- Upgrade OTel to `v1.34.0/v0.56.0`. (#412)
- Update the comment for the `WithAttributes` option to correctly describe the behavior on measurement creation. (#413)
- Upgrade semantic conventions to `semconv/v1.24.0`. (#418)