### PR TITLE
Add error attribute to metrics labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `WithInstrumentErrorAttributesGetter` option to provide additional error-related attributes. (#440)
+
 ### Removed
 
 - Drop support for Go `1.23`. (#447)

--- a/config.go
+++ b/config.go
@@ -43,6 +43,9 @@ type AttributesGetter func(ctx context.Context, method Method, query string, arg
 // InstrumentAttributesGetter provides additional attributes while recording metrics to instruments.
 type InstrumentAttributesGetter func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue
 
+// InstrumentErrorAttributesGetter provides additional error-related attributes while recording metrics to instruments.
+type InstrumentErrorAttributesGetter func(err error) []attribute.KeyValue
+
 type SpanFilter func(ctx context.Context, method Method, query string, args []driver.NamedValue) bool
 
 type config struct {
@@ -80,6 +83,8 @@ type config struct {
 	// InstrumentAttributesGetter will be called to produce additional attributes while recording metrics to instruments.
 	// Default returns nil
 	InstrumentAttributesGetter InstrumentAttributesGetter
+
+	InstrumentErrorAttributesGetter InstrumentErrorAttributesGetter
 
 	// DisableSkipErrMeasurement, if set to true, will suppress driver.ErrSkip as an error status in measurements.
 	// The measurement will be recorded as status=ok.

--- a/option.go
+++ b/option.go
@@ -116,3 +116,10 @@ func WithDisableSkipErrMeasurement(disable bool) Option {
 		cfg.DisableSkipErrMeasurement = disable
 	})
 }
+
+// WithInstrumentErrorAttributesGetter takes InstrumentErrorAttributesGetter that will be called every time metric is recorded to instruments.
+func WithInstrumentErrorAttributesGetter(instrumentErrorAttributesGetter InstrumentErrorAttributesGetter) Option {
+	return OptionFunc(func(cfg *config) {
+		cfg.InstrumentErrorAttributesGetter = instrumentErrorAttributesGetter
+	})
+}

--- a/option_test.go
+++ b/option_test.go
@@ -33,6 +33,10 @@ func TestOptions(t *testing.T) {
 		return []attribute.KeyValue{attribute.String("foo", "bar")}
 	}
 
+	dummyErrorAttributesGetter := func(_ error) []attribute.KeyValue {
+		return []attribute.KeyValue{attribute.String("errorKey", "errorVal")}
+	}
+
 	testCases := []struct {
 		name           string
 		option         Option
@@ -89,6 +93,11 @@ func TestOptions(t *testing.T) {
 			option:         WithDisableSkipErrMeasurement(true),
 			expectedConfig: config{DisableSkipErrMeasurement: true},
 		},
+		{
+			name:           "WithInstrumentErrorAttributesGetter",
+			option:         WithInstrumentErrorAttributesGetter(dummyErrorAttributesGetter),
+			expectedConfig: config{InstrumentErrorAttributesGetter: dummyErrorAttributesGetter},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -101,6 +110,8 @@ func TestOptions(t *testing.T) {
 				assert.Equal(t, tc.expectedConfig.AttributesGetter(context.Background(), "", "", nil), cfg.AttributesGetter(context.Background(), "", "", nil))
 			} else if tc.expectedConfig.InstrumentAttributesGetter != nil {
 				assert.Equal(t, tc.expectedConfig.InstrumentAttributesGetter(context.Background(), "", "", nil), cfg.InstrumentAttributesGetter(context.Background(), "", "", nil))
+			} else if tc.expectedConfig.InstrumentErrorAttributesGetter != nil {
+				assert.Equal(t, tc.expectedConfig.InstrumentErrorAttributesGetter(assert.AnError), cfg.InstrumentErrorAttributesGetter(assert.AnError))
 			} else {
 				assert.Equal(t, tc.expectedConfig, cfg)
 			}

--- a/utils.go
+++ b/utils.go
@@ -70,6 +70,10 @@ func recordMetric(
 			attributes = append(attributes, cfg.InstrumentAttributesGetter(ctx, method, query, args)...)
 		}
 		if err != nil {
+			if cfg.InstrumentErrorAttributesGetter != nil {
+				attributes = append(attributes, cfg.InstrumentErrorAttributesGetter(err)...)
+			}
+
 			if cfg.DisableSkipErrMeasurement && err == driver.ErrSkip {
 				attributes = append(attributes, queryStatusKey.String("ok"))
 			} else {


### PR DESCRIPTION
This PR allows you to add specific information about an error to a metric when it occurs. For instance the mysql error code.

An example implementation of the `ErrorAttributesGetter` function for mysql:

```
// For information on MySQL errors and mappings, see https://dev.mysql.com/doc/mysql-errors/5.7/en/server-error-reference.html
func MySQLErrorAttributesGetter(err error) []attribute.KeyValue {
	var mysqlError *mysql.MySQLError
	if errors.As(err, &mysqlError) {
		return []attribute.KeyValue{
			attribute.String("error_type", "mysql"),
			attribute.String("error_number", strconv.FormatUint(uint64(mysqlError.Number), 10)),
		}
	}

	return nil
}
```

This would be registered with:

```
driverName, err := otelsql.Register("mysql",otelsql.WithErrorAttributesGetter(MySQLErrorAttributesGetter))
```

It creates a metric that looks something like:

```
db_sql_latency_milliseconds_bucket{error_number="1062",error_type="mysql",method="sql.stmt.exec",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.36.0",status="error",le="100"} 1
```

instead of:

```
db_sql_latency_milliseconds_bucket{method="sql.stmt.exec",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.36.0",status="error",le="100"} 1
```

This allows us to use the error number to decide if an error is a critical error or one that is already being managed in code.