### PR TITLE
Fix data race when recording metrics and spans

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,8 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('./internal/tools/**') }}
       - name: Run tests with race detector
         run: make test-race
+      - name: Run benchmarks with race detector
+        run: make test-bench
 
   test-coverage:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Upgrade semantic conventions to `semconv/v1.30.0`. (#478)
+- Improve memory usage when recording metrics or creating spans. (#497)
+
+### Fixed
+
+- Data race issues when recording metrics or creating spans. (#497)
 
 ## [0.38.0] - 2025-03-26
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ build: generate
 TEST_TARGETS := test-default test-bench test-short test-verbose test-race
 .PHONY: $(TEST_TARGETS) test
 test-default: ARGS=-v -race
-test-bench:   ARGS=-run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=.
+# Check functionality of the code, not the performance
+test-bench:   ARGS=-run=xxxxxMatchNothingxxxxx -test.benchtime=1ms -bench=. -race
 test-short:   ARGS=-short
 test-verbose: ARGS=-v
 test-race:    ARGS=-race

--- a/sql.go
+++ b/sql.go
@@ -150,6 +150,7 @@ func recordDBStatsMetrics(
 		metric.WithAttributes(cfg.Attributes...),
 	)
 
+	// TODO: optimize slice allocation.
 	observer.ObserveInt64(instruments.connectionOpen,
 		int64(dbStats.InUse),
 		metric.WithAttributes(append(cfg.Attributes, connectionStatusKey.String("inuse"))...),

--- a/utils.go
+++ b/utils.go
@@ -33,7 +33,7 @@ import (
 // This value 5 is borrowed from slog which
 // performed a quantitative survey of log library use and found this value to
 // cover 95% of all use-cases (https://go.dev/blog/slog#performance).
-// This may not be accurate for metrics or spans, but it's a good starting point.
+// This may not be accurate for metrics or traces, but it's a good starting point.
 const estimatedAttributesOfGettersCount = 5
 
 var timeNow = time.Now

--- a/utils.go
+++ b/utils.go
@@ -129,7 +129,11 @@ func recordMetric(
 
 		// number of attributes + estimated 5 from InstrumentAttributesGetter and
 		// InstrumentErrorAttributesGetter + estimated 2 from recordDuration.
-		attributes := make([]attribute.KeyValue, len(cfg.Attributes), len(cfg.Attributes)+estimatedAttributesOfGettersCount+2)
+		attributes := make(
+			[]attribute.KeyValue,
+			len(cfg.Attributes),
+			len(cfg.Attributes)+estimatedAttributesOfGettersCount+2,
+		)
 		copy(attributes, cfg.Attributes)
 
 		if cfg.InstrumentAttributesGetter != nil {
@@ -163,7 +167,11 @@ func createSpan(
 	args []driver.NamedValue,
 ) (context.Context, trace.Span) {
 	// number of attributes + estimated 5 from AttributesGetter + estimated 2 from DBQueryTextAttributes.
-	attributes := make([]attribute.KeyValue, len(cfg.Attributes), len(cfg.Attributes)+estimatedAttributesOfGettersCount+2)
+	attributes := make(
+		[]attribute.KeyValue,
+		len(cfg.Attributes),
+		len(cfg.Attributes)+estimatedAttributesOfGettersCount+2,
+	)
 	copy(attributes, cfg.Attributes)
 
 	if enableDBStatement && !cfg.SpanOptions.DisableQuery {

--- a/utils.go
+++ b/utils.go
@@ -29,6 +29,13 @@ import (
 	internalsemconv "github.com/XSAM/otelsql/internal/semconv"
 )
 
+// estimatedAttributesOfGettersCount is the estimated number of attributes from getter methods.
+// This value 5 is borrowed from slog which
+// performed a quantitative survey of log library use and found this value to
+// cover 95% of all use-cases (https://go.dev/blog/slog#performance).
+// This may not be accurate for metrics or spans, but it's a good starting point.
+const estimatedAttributesOfGettersCount = 5
+
 var timeNow = time.Now
 
 func recordSpanErrorDeferred(span trace.Span, opts SpanOptions, err *error) {
@@ -120,7 +127,11 @@ func recordMetric(
 	return func(err error) {
 		duration := timeNow().Sub(startTime)
 
-		attributes := cfg.Attributes
+		// number of attributes + estimated 5 from InstrumentAttributesGetter and
+		// InstrumentErrorAttributesGetter + estimated 2 from recordDuration.
+		attributes := make([]attribute.KeyValue, len(cfg.Attributes), len(cfg.Attributes)+estimatedAttributesOfGettersCount+2)
+		copy(attributes, cfg.Attributes)
+
 		if cfg.InstrumentAttributesGetter != nil {
 			attributes = append(attributes, cfg.InstrumentAttributesGetter(ctx, method, query, args)...)
 		}
@@ -151,17 +162,20 @@ func createSpan(
 	query string,
 	args []driver.NamedValue,
 ) (context.Context, trace.Span) {
-	attrs := cfg.Attributes
+	// number of attributes + estimated 5 from AttributesGetter + estimated 2 from DBQueryTextAttributes.
+	attributes := make([]attribute.KeyValue, len(cfg.Attributes), len(cfg.Attributes)+estimatedAttributesOfGettersCount+2)
+	copy(attributes, cfg.Attributes)
+
 	if enableDBStatement && !cfg.SpanOptions.DisableQuery {
-		attrs = append(attrs, cfg.DBQueryTextAttributes(query)...)
+		attributes = append(attributes, cfg.DBQueryTextAttributes(query)...)
 	}
 	if cfg.AttributesGetter != nil {
-		attrs = append(attrs, cfg.AttributesGetter(ctx, method, query, args)...)
+		attributes = append(attributes, cfg.AttributesGetter(ctx, method, query, args)...)
 	}
 
 	return cfg.Tracer.Start(ctx, cfg.SpanNameFormatter(ctx, method, query),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(attrs...),
+		trace.WithAttributes(attributes...),
 	)
 }
 

--- a/utils_bench_test.go
+++ b/utils_bench_test.go
@@ -17,7 +17,6 @@ package otelsql
 import (
 	"context"
 	"database/sql/driver"
-
 	"testing"
 
 	internalsemconv "github.com/XSAM/otelsql/internal/semconv"
@@ -49,7 +48,7 @@ func BenchmarkRecordMetric(b *testing.B) {
 	b.Run("InstrumentAttributesGetter", func(b *testing.B) {
 		b.Run("5", func(b *testing.B) {
 			cfg := cfg
-			cfg.InstrumentAttributesGetter = func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+			cfg.InstrumentAttributesGetter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 				return attrs5
 			}
 
@@ -57,7 +56,14 @@ func BenchmarkRecordMetric(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					recordFunc := recordMetric(context.Background(), cfg.Instruments, cfg, MethodStmtQuery, "SELECT 1", nil)
+					recordFunc := recordMetric(
+						context.Background(),
+						cfg.Instruments,
+						cfg,
+						MethodStmtQuery,
+						"SELECT 1",
+						nil,
+					)
 					recordFunc(nil)
 				}
 			})
@@ -65,7 +71,7 @@ func BenchmarkRecordMetric(b *testing.B) {
 
 		b.Run("10", func(b *testing.B) {
 			cfg := cfg
-			cfg.InstrumentAttributesGetter = func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+			cfg.InstrumentAttributesGetter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 				return attrs10
 			}
 
@@ -73,7 +79,14 @@ func BenchmarkRecordMetric(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					recordFunc := recordMetric(context.Background(), cfg.Instruments, cfg, MethodStmtQuery, "SELECT 1", nil)
+					recordFunc := recordMetric(
+						context.Background(),
+						cfg.Instruments,
+						cfg,
+						MethodStmtQuery,
+						"SELECT 1",
+						nil,
+					)
 					recordFunc(nil)
 				}
 			})
@@ -92,7 +105,7 @@ func BenchmarkCreateSpan(b *testing.B) {
 	b.Run("AttributesGetter", func(b *testing.B) {
 		b.Run("5", func(b *testing.B) {
 			cfg := cfg
-			cfg.AttributesGetter = func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+			cfg.AttributesGetter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 				return attrs5
 			}
 
@@ -107,7 +120,7 @@ func BenchmarkCreateSpan(b *testing.B) {
 
 		b.Run("10", func(b *testing.B) {
 			cfg := cfg
-			cfg.AttributesGetter = func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+			cfg.AttributesGetter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 				return attrs10
 			}
 

--- a/utils_bench_test.go
+++ b/utils_bench_test.go
@@ -1,0 +1,123 @@
+// Copyright Sam Xie
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsql
+
+import (
+	"context"
+	"database/sql/driver"
+
+	"testing"
+
+	internalsemconv "github.com/XSAM/otelsql/internal/semconv"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var (
+	attrs10 = []attribute.KeyValue{
+		attribute.Bool("b1", true),
+		attribute.Int("i1", 324),
+		attribute.Float64("f1", -230.213),
+		attribute.String("s1", "value1"),
+		attribute.String("s2", "value2"),
+		attribute.Bool("b2", false),
+		attribute.Int("i2", 39847),
+		attribute.Float64("f2", 0.382964329),
+		attribute.String("s3", "value3"),
+		attribute.String("s4", "value4"),
+	}
+	attrs5 = attrs10[:5]
+)
+
+func BenchmarkRecordMetric(b *testing.B) {
+	cfg := newConfig()
+	cfg.SemConvStabilityOptIn = internalsemconv.OTelSemConvStabilityOptInStable
+	// Prevent reallocation of Attributes slice, which increase the chance to detect data races.
+	cfg.Attributes = make([]attribute.KeyValue, 0, 10)
+
+	b.Run("InstrumentAttributesGetter", func(b *testing.B) {
+		b.Run("5", func(b *testing.B) {
+			cfg := cfg
+			cfg.InstrumentAttributesGetter = func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+				return attrs5
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					recordFunc := recordMetric(context.Background(), cfg.Instruments, cfg, MethodStmtQuery, "SELECT 1", nil)
+					recordFunc(nil)
+				}
+			})
+		})
+
+		b.Run("10", func(b *testing.B) {
+			cfg := cfg
+			cfg.InstrumentAttributesGetter = func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+				return attrs10
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					recordFunc := recordMetric(context.Background(), cfg.Instruments, cfg, MethodStmtQuery, "SELECT 1", nil)
+					recordFunc(nil)
+				}
+			})
+		})
+	})
+}
+
+func BenchmarkCreateSpan(b *testing.B) {
+	cfg := newConfig()
+	cfg.SemConvStabilityOptIn = internalsemconv.OTelSemConvStabilityOptInStable
+	// Prevent reallocation of Attributes slice, which increase the chance to detect data races.
+	cfg.Attributes = make([]attribute.KeyValue, 0, 10)
+
+	ctx := context.Background()
+
+	b.Run("AttributesGetter", func(b *testing.B) {
+		b.Run("5", func(b *testing.B) {
+			cfg := cfg
+			cfg.AttributesGetter = func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+				return attrs5
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_, _ = createSpan(ctx, cfg, MethodStmtQuery, true, "SELECT 1", nil)
+				}
+			})
+		})
+
+		b.Run("10", func(b *testing.B) {
+			cfg := cfg
+			cfg.AttributesGetter = func(ctx context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+				return attrs10
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_, _ = createSpan(ctx, cfg, MethodStmtQuery, true, "SELECT 1", nil)
+				}
+			})
+		})
+	})
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1120,7 +1120,8 @@ func TestRecordMetric(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metricReader, meterProvider := prepareMetrics()
-			cfg := newConfig(append(tt.cfgOptions, WithMeterProvider(meterProvider), WithAttributes(defaultattribute))...)
+			cfg := newConfig(
+				append(tt.cfgOptions, WithMeterProvider(meterProvider), WithAttributes(defaultattribute))...)
 			cfg.SemConvStabilityOptIn = tt.semConvStabilityOptIn
 
 			timeNow = func() time.Time {

--- a/utils_test.go
+++ b/utils_test.go
@@ -321,6 +321,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 											),
 										},
@@ -378,6 +379,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 												attribute.String("error.type", "*errors.errorString"),
 											),
@@ -436,6 +438,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 												attribute.String("error.type", "database/sql/driver.ErrSkip"),
 											),
@@ -495,6 +498,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 											),
 										},
@@ -558,6 +562,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("dummyKey", "dummyVal"),
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 											),
@@ -619,6 +624,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("errorKey", "errorVal"),
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 												attribute.String("error.type", "*errors.errorString"),
@@ -680,6 +686,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 											),
 										},
@@ -737,6 +744,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2000),
 											Max:          metricdata.NewExtrema[float64](2000),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("method", string(MethodConnQuery)),
 												attribute.String("status", "ok"),
 											),
@@ -776,6 +784,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 											),
 										},
@@ -833,6 +842,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2000),
 											Max:          metricdata.NewExtrema[float64](2000),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("method", string(MethodConnQuery)),
 												attribute.String("status", "ok"),
 											),
@@ -892,6 +902,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2000),
 											Max:          metricdata.NewExtrema[float64](2000),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("method", string(MethodConnQuery)),
 												attribute.String("status", "error"),
 											),
@@ -931,6 +942,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 												attribute.String("error.type", "*errors.errorString"),
 											),
@@ -990,6 +1002,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2000),
 											Max:          metricdata.NewExtrema[float64](2000),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("method", string(MethodConnQuery)),
 												attribute.String("status", "error"),
 											),
@@ -1050,6 +1063,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2000),
 											Max:          metricdata.NewExtrema[float64](2000),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("method", string(MethodConnQuery)),
 												attribute.String("status", "ok"),
 											),
@@ -1089,6 +1103,7 @@ func TestRecordMetric(t *testing.T) {
 											Min:          metricdata.NewExtrema[float64](2),
 											Max:          metricdata.NewExtrema[float64](2),
 											Attributes: attribute.NewSet(
+												defaultattribute,
 												attribute.String("db.operation.name", string(MethodConnQuery)),
 											),
 										},
@@ -1105,7 +1120,7 @@ func TestRecordMetric(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metricReader, meterProvider := prepareMetrics()
-			cfg := newConfig(append(tt.cfgOptions, WithMeterProvider(meterProvider))...)
+			cfg := newConfig(append(tt.cfgOptions, WithMeterProvider(meterProvider), WithAttributes(defaultattribute))...)
 			cfg.SemConvStabilityOptIn = tt.semConvStabilityOptIn
 
 			timeNow = func() time.Time {


### PR DESCRIPTION
Resolve #496. This is a corner case where a data race would happen.

The performance is also improved for most cases:

```
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/XSAM/otelsql
cpu: Apple M1 Max
                                              │   old.txt   │               new.txt               │
                                              │   sec/op    │   sec/op     vs base                │
RecordMetric/InstrumentAttributesGetter/5-10    609.8n ± 3%   443.6n ± 2%  -27.26% (p=0.000 n=10)
RecordMetric/InstrumentAttributesGetter/10-10   1.471µ ± 1%   1.347µ ± 2%   -8.46% (p=0.000 n=10)
CreateSpan/AttributesGetter/5-10                287.9n ± 6%   277.7n ± 1%   -3.54% (p=0.000 n=10)
CreateSpan/AttributesGetter/10-10               387.9n ± 1%   525.5n ± 1%  +35.46% (p=0.000 n=10)
geomean                                         562.6n        543.3n        -3.42%

                                              │   old.txt    │                new.txt                 │
                                              │     B/op     │     B/op      vs base                  │
RecordMetric/InstrumentAttributesGetter/5-10    1.781Ki ± 0%   1.219Ki ± 0%  -31.58% (p=0.000 n=10)
RecordMetric/InstrumentAttributesGetter/10-10   4.344Ki ± 0%   3.719Ki ± 0%  -14.39% (p=0.000 n=10)
CreateSpan/AttributesGetter/5-10                  824.0 ± 0%     824.0 ± 0%        ~ (p=1.000 n=10) ¹
CreateSpan/AttributesGetter/10-10               1.180Ki ± 0%   1.805Ki ± 0%  +52.98% (p=0.000 n=10)
geomean                                         1.646Ki        1.602Ki        -2.71%
¹ all samples are equal

                                              │  old.txt   │               new.txt                │
                                              │ allocs/op  │ allocs/op   vs base                  │
RecordMetric/InstrumentAttributesGetter/5-10    6.000 ± 0%   5.000 ± 0%  -16.67% (p=0.000 n=10)
RecordMetric/InstrumentAttributesGetter/10-10   7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=10) ¹
CreateSpan/AttributesGetter/5-10                9.000 ± 0%   8.000 ± 0%  -11.11% (p=0.000 n=10)
CreateSpan/AttributesGetter/10-10               9.000 ± 0%   9.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                         7.637        7.085        -7.23%
¹ all samples are equal
```

This performance can be further improved, but it is not within the scope of this PR.