### PR TITLE
Release v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.40.0] - 2025-09-08
+
 This release is the last to support [Go 1.23].
 The next release will require at least [Go 1.24].
 
@@ -473,7 +475,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 [Go 1.24]: https://go.dev/doc/go1.24
 [Go 1.23]: https://go.dev/doc/go1.23
 
-[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.39.0...HEAD
+[Unreleased]: https://github.com/XSAM/otelsql/compare/v0.40.0...HEAD
+[0.40.0]: https://github.com/XSAM/otelsql/releases/tag/v0.40.0
 [0.39.0]: https://github.com/XSAM/otelsql/releases/tag/v0.39.0
 [0.38.0]: https://github.com/XSAM/otelsql/releases/tag/v0.38.0
 [0.37.0]: https://github.com/XSAM/otelsql/releases/tag/v0.37.0

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otelsql
 
 // Version is the current release version of otelsql in use.
 func Version() string {
-	return "0.39.0"
+	return "0.40.0"
 }


### PR DESCRIPTION
This release is the last to support [Go 1.23].
The next release will require at least [Go 1.24].

### Added

- Support testing of [Go 1.25]. (#517)

### Changed

- Upgrade OTel to `v1.38.0/v0.60.0`. (#510)

[Go 1.25]: https://go.dev/doc/go1.25
[Go 1.24]: https://go.dev/doc/go1.24
[Go 1.23]: https://go.dev/doc/go1.23