### PR TITLE
Allow configuring a TextMapPropagator for SQLCommenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `WithTextMapPropagator` allows customization of the OTel text map propagator used by SQLCommenter. (#540)
+  This is an experimental feature and may be changed or removed in a later release.
+
 ### Removed
 
 - Drop support for [Go 1.23]. (#533)

--- a/commenter.go
+++ b/commenter.go
@@ -45,10 +45,14 @@ type commenter struct {
 	propagator propagation.TextMapPropagator
 }
 
-func newCommenter(enabled bool) *commenter {
+func newCommenter(enabled bool, propagator propagation.TextMapPropagator) *commenter {
+	if propagator == nil {
+		propagator = otel.GetTextMapPropagator()
+	}
+
 	return &commenter{
 		enabled:    enabled,
-		propagator: otel.GetTextMapPropagator(),
+		propagator: propagator,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
 	internalsemconv "github.com/XSAM/otelsql/internal/semconv"
@@ -79,6 +80,7 @@ type config struct {
 	// later release.
 	SQLCommenterEnabled bool
 	SQLCommenter        *commenter
+	TextMapPropagator   propagation.TextMapPropagator
 
 	// AttributesGetter will be called to produce additional attributes while creating spans.
 	// Default returns nil
@@ -179,7 +181,7 @@ func newConfig(options ...Option) config {
 		metric.WithInstrumentationVersion(Version()),
 	)
 
-	cfg.SQLCommenter = newCommenter(cfg.SQLCommenterEnabled)
+	cfg.SQLCommenter = newCommenter(cfg.SQLCommenterEnabled, cfg.TextMapPropagator)
 
 	var err error
 	if cfg.Instruments, err = newInstruments(cfg.Meter); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -69,7 +69,7 @@ func TestNewConfig(t *testing.T) {
 		Attributes: []attribute.KeyValue{
 			semconv.DBSystemNameMySQL,
 		},
-		SQLCommenter:          newCommenter(false),
+		SQLCommenter:          newCommenter(false, otel.GetTextMapPropagator()),
 		SemConvStabilityOptIn: internalsemconv.OTelSemConvStabilityOptInNone,
 	}, cfg)
 	assert.NotNil(t, cfg.Instruments)

--- a/option.go
+++ b/option.go
@@ -17,6 +17,7 @@ package otelsql
 import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -92,6 +93,17 @@ func WithMeterProvider(provider metric.MeterProvider) Option {
 func WithSQLCommenter(enabled bool) Option {
 	return OptionFunc(func(cfg *config) {
 		cfg.SQLCommenterEnabled = enabled
+	})
+}
+
+// WithTextMapPropagator specifies a text map propagator to used by the SQLCommenter
+// option. If none is specified, the global text map propagator is used.
+//
+// Notice: This option is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func WithTextMapPropagator(propagator propagation.TextMapPropagator) Option {
+	return OptionFunc(func(cfg *config) {
+		cfg.TextMapPropagator = propagator
 	})
 }
 

--- a/option_test.go
+++ b/option_test.go
@@ -22,12 +22,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestOptions(t *testing.T) {
 	tracerProvider := sdktrace.NewTracerProvider()
 	meterProvider := noop.NewMeterProvider()
+	textMapPropagator := propagation.NewCompositeTextMapPropagator()
 
 	dummyAttributesGetter := func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 		return []attribute.KeyValue{attribute.String("foo", "bar")}
@@ -77,6 +79,13 @@ func TestOptions(t *testing.T) {
 			name:           "WithSQLCommenter",
 			option:         WithSQLCommenter(true),
 			expectedConfig: config{SQLCommenterEnabled: true},
+		},
+		{
+			name:   "WithTextMapPropagator",
+			option: WithTextMapPropagator(textMapPropagator),
+			expectedConfig: config{
+				TextMapPropagator: textMapPropagator,
+			},
 		},
 		{
 			name:           "WithAttributesGetter",


### PR DESCRIPTION
This allows users to not rely on the global TextMapPropagator. It might be enough to close https://github.com/XSAM/otelsql/issues/192 because then users are free to implement a custom propagator which is specific for the SQLCommenter use case without polluting the global TextMapPropagator.