### PR TITLE
Add WithOperationNameSetter to allow control of the operation name sent to metrics

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,6 +49,9 @@ type InstrumentAttributesGetter func(ctx context.Context, method Method, query s
 // InstrumentErrorAttributesGetter provides additional error-related attributes while recording metrics to instruments.
 type InstrumentErrorAttributesGetter func(err error) []attribute.KeyValue
 
+// OperationNameSetter allows controlling the operation name provided to metric instruments.
+type OperationNameSetter func(ctx context.Context, method Method, query string) string
+
 // SpanFilter is a function that determines whether a span should be created for a given SQL operation.
 // It returns true if the span should be created, or false to skip span creation.
 type SpanFilter func(ctx context.Context, method Method, query string, args []driver.NamedValue) bool
@@ -91,6 +94,10 @@ type config struct {
 	InstrumentAttributesGetter InstrumentAttributesGetter
 
 	InstrumentErrorAttributesGetter InstrumentErrorAttributesGetter
+
+	// OperationNameSetter will be called to produce the operation name for metric instruments.
+	// If nil, the default behavior uses the method name.
+	OperationNameSetter OperationNameSetter
 
 	// DisableSkipErrMeasurement, if set to true, will suppress driver.ErrSkip as an error status in metrics.
 	// The metric measurement will be recorded as status=ok.

--- a/option.go
+++ b/option.go
@@ -140,3 +140,11 @@ func WithInstrumentErrorAttributesGetter(instrumentErrorAttributesGetter Instrum
 		cfg.InstrumentErrorAttributesGetter = instrumentErrorAttributesGetter
 	})
 }
+
+// WithOperationNameSetter takes OperationNameSetter that will be called to produce the operation name for metric instruments.
+// If not set, the default behavior uses the method name.
+func WithOperationNameSetter(operationNameSetter OperationNameSetter) Option {
+	return OptionFunc(func(cfg *config) {
+		cfg.OperationNameSetter = operationNameSetter
+	})
+}

--- a/option_test.go
+++ b/option_test.go
@@ -39,6 +39,10 @@ func TestOptions(t *testing.T) {
 		return []attribute.KeyValue{attribute.String("errorKey", "errorVal")}
 	}
 
+	dummyOperationNameSetter := func(_ context.Context, _ Method, _ string) string {
+		return "custom_operation"
+	}
+
 	testCases := []struct {
 		name           string
 		options        []Option
@@ -108,6 +112,11 @@ func TestOptions(t *testing.T) {
 			name:           "WithInstrumentErrorAttributesGetter",
 			options:        []Option{WithInstrumentErrorAttributesGetter(dummyErrorAttributesGetter)},
 			expectedConfig: config{InstrumentErrorAttributesGetter: dummyErrorAttributesGetter},
+		},
+		{
+			name:           "WithOperationNameSetter",
+			options:        []Option{WithOperationNameSetter(dummyOperationNameSetter)},
+			expectedConfig: config{OperationNameSetter: dummyOperationNameSetter},
 		},
 		{
 			name: "WithAttributes multiple calls should accumulate",
@@ -206,6 +215,12 @@ func TestOptions(t *testing.T) {
 					t,
 					tc.expectedConfig.InstrumentErrorAttributesGetter(assert.AnError),
 					cfg.InstrumentErrorAttributesGetter(assert.AnError),
+				)
+			case tc.expectedConfig.OperationNameSetter != nil:
+				assert.Equal(
+					t,
+					tc.expectedConfig.OperationNameSetter(context.Background(), "", ""),
+					cfg.OperationNameSetter(context.Background(), "", ""),
 				)
 			default:
 				assert.Equal(t, tc.expectedConfig, cfg)


### PR DESCRIPTION
Recreating this from a branch so I can update the module path on my fork.

This allows folks to customise the operation name attribute sent on metrics.

The signature is the same as the SpanNameFormatter, so the same function could be used for both, which is probably generally desirable.

Potentially so desirable, that we could avoid the second config option and always do this, but this has better BC.