### PR TITLE
Add DBNamespaceFromDSN helper and fix AttributesFromDSN bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Introduce helper function `DBNamespaceFromDSN` to extract the `db.namespace` attribute from a DSN string.
+
 ### Changed
 
 - Upgrade OTel Semconv to `v1.40.0`. (#606)
@@ -15,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Implement `driver.Validator` on `otConn` so that `database/sql` connection pool health checks are properly delegated to the underlying driver connection. (#619)
+- Fix panic in `AttributesFromDSN` when the closing protocol parenthesis is missing and the DSN has no path nor query string.
+- Fix `server.port` parsing in `AttributesFromDSN` when the DSN has no path but has a query string.
 
 ## [0.42.0] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Introduce helper function `DBNamespaceFromDSN` to extract the `db.namespace` attribute from a DSN string.
+  Supported schemes: `postgresql`, `postgres`, `mysql`, `clickhouse`, `sqlserver`, `mssql`.
+  All other schemes and scheme-less DSNs return an error.
 
 ### Changed
 

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -177,6 +177,10 @@ func main() {
 func connectDB() (*sql.DB, func()) {
 	attrs := append(otelsql.AttributesFromDSN(mysqlDSN), semconv.DBSystemNameMySQL)
 
+	if dbNamespace, err := otelsql.DBNamespaceFromDSN(mysqlDSN); err == nil {
+		attrs = append(attrs, dbNamespace)
+	}
+
 	// Connect to database
 	db, err := otelsql.Open("mysql", mysqlDSN, otelsql.WithAttributes(
 		attrs...,

--- a/example/stdout/main.go
+++ b/example/stdout/main.go
@@ -98,6 +98,10 @@ func main() {
 
 	attrs := append(otelsql.AttributesFromDSN(mysqlDSN), semconv.DBSystemNameMySQL)
 
+	if dbNamespace, err := otelsql.DBNamespaceFromDSN(mysqlDSN); err == nil {
+		attrs = append(attrs, dbNamespace)
+	}
+
 	// Connect to database
 	db, err := otelsql.Open("mysql", mysqlDSN, otelsql.WithAttributes(
 		attrs...,

--- a/helpers.go
+++ b/helpers.go
@@ -15,7 +15,9 @@
 package otelsql
 
 import (
+	"errors"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -26,7 +28,7 @@ import (
 // AttributesFromDSN returns attributes extracted from a DSN string.
 // It makes the best effort to retrieve values for [semconv.ServerAddressKey] and [semconv.ServerPortKey].
 func AttributesFromDSN(dsn string) []attribute.KeyValue {
-	// [scheme://][user[:password]@][protocol([addr])]/dbname[?param1=value1&paramN=valueN]
+	// [scheme://][user[:password]@][protocol([addr])][/path][?param1=value1&paramN=valueN]
 	// Find the schema part.
 	schemaIndex := strings.Index(dsn, "://")
 	if schemaIndex != -1 {
@@ -34,7 +36,7 @@ func AttributesFromDSN(dsn string) []attribute.KeyValue {
 		dsn = dsn[schemaIndex+3:]
 	}
 
-	// [user[:password]@][protocol([addr])]/dbname[?param1=value1&paramN=valueN]
+	// [user[:password]@][protocol([addr])][/path][?param1=value1&paramN=valueN]
 	// Find credentials part.
 	atIndex := strings.Index(dsn, "@")
 	if atIndex != -1 {
@@ -42,7 +44,14 @@ func AttributesFromDSN(dsn string) []attribute.KeyValue {
 		dsn = dsn[atIndex+1:]
 	}
 
-	// [protocol([addr])]/dbname[?param1=value1&paramN=valueN]
+	// [protocol([addr])][/path][?param1=value1&paramN=valueN]
+	// Find the '?' that separates the query string.
+	if questionMarkIndex := strings.Index(dsn, "?"); questionMarkIndex != -1 {
+		// Remove queryString part from the DSN
+		dsn = dsn[:questionMarkIndex]
+	}
+
+	// [protocol([addr])]/path
 	// Find the '/' that separates the address part from the database part.
 	pathIndex := strings.Index(dsn, "/")
 	if pathIndex != -1 {
@@ -54,8 +63,12 @@ func AttributesFromDSN(dsn string) []attribute.KeyValue {
 	// Find the '(' that starts the address part.
 	openParen := strings.Index(dsn, "(")
 	if openParen != -1 {
+		rest := dsn[openParen+1:]
+		if closeParen := strings.Index(rest, ")"); closeParen != -1 {
+			rest = rest[:closeParen]
+		}
 		// Remove the protocol part from the DSN.
-		dsn = dsn[openParen+1 : len(dsn)-1]
+		dsn = rest
 	}
 
 	// [addr]
@@ -81,4 +94,63 @@ func AttributesFromDSN(dsn string) []attribute.KeyValue {
 	}
 
 	return attrs
+}
+
+// errDBNamespaceNotFound is returned by [DBNamespaceFromDSN] when no database name can be extracted from the DSN.
+var errDBNamespaceNotFound = errors.New("db namespace not found in DSN")
+
+// DBNamespaceFromDSN extracts the OpenTelemetry db.namespace resource attribute from a DSN string and returns it as
+// an [semconv.DBNamespaceKey] attribute.
+// It handles the format: [scheme://][user[:password]@][protocol([addr])][/path][?param1=value1&paramN=valueN]
+// Returns [errDBNamespaceNotFound] if the database name is not found.
+func DBNamespaceFromDSN(dsn string) (attribute.KeyValue, error) {
+	// [scheme://][user[:password]@][protocol([addr])][/path][?param1=value1&paramN=valueN]
+	// Find the schema part.
+	var scheme string
+	schemaIndex := strings.Index(dsn, "://")
+	if schemaIndex != -1 {
+		scheme = dsn[:schemaIndex]
+		// Remove the schema part from the DSN.
+		dsn = dsn[schemaIndex+3:]
+	}
+
+	// [user[:password]@][protocol([addr])][/path][?param1=value1&paramN=valueN]
+	// Find credentials part.
+	if atIndex := strings.Index(dsn, "@"); atIndex != -1 {
+		// Remove the credential part from the DSN.
+		dsn = dsn[atIndex+1:]
+	}
+
+	// [protocol([addr])][/path][?param1=value1&paramN=valueN]
+	// Find the '?' that separates the query string.
+	var queryString string
+	if questionMarkIndex := strings.Index(dsn, "?"); questionMarkIndex != -1 {
+		queryString = dsn[questionMarkIndex+1:]
+		// Remove queryString part from the DSN
+		dsn = dsn[:questionMarkIndex]
+	}
+
+	// [protocol([addr])][/path]
+	// Find the '/' that separates the address part from the path (database or instance name).
+	pathIndex := strings.Index(dsn, "/")
+	var path string
+	if pathIndex != -1 {
+		path = dsn[pathIndex+1:]
+	}
+
+	if scheme == "oracle" {
+		return attribute.KeyValue{}, errDBNamespaceNotFound
+	}
+	if scheme == "sqlserver" {
+		if params, err := url.ParseQuery(queryString); err == nil {
+			if db := params.Get("database"); db != "" {
+				return semconv.DBNamespace(db), nil
+			}
+		}
+		return attribute.KeyValue{}, errDBNamespaceNotFound
+	}
+	if path == "" {
+		return attribute.KeyValue{}, errDBNamespaceNotFound
+	}
+	return semconv.DBNamespace(path), nil
 }

--- a/helpers.go
+++ b/helpers.go
@@ -66,9 +66,11 @@ func AttributesFromDSN(dsn string) []attribute.KeyValue {
 	if host != "" {
 		attrs = append(attrs, semconv.ServerAddress(host))
 	}
+
 	if port != -1 {
 		attrs = append(attrs, semconv.ServerPortKey.Int64(port))
 	}
+
 	return attrs
 }
 
@@ -84,6 +86,7 @@ func parseHostPort(dsn string) (serverAddress string, serverPort int64) {
 		if closeParen := strings.Index(rest, ")"); closeParen != -1 {
 			rest = rest[:closeParen]
 		}
+
 		dsn = rest
 	}
 
@@ -97,9 +100,11 @@ func parseHostPort(dsn string) (serverAddress string, serverPort int64) {
 	}
 
 	serverAddress = host
+
 	if port, err := strconv.ParseInt(portStr, 10, 64); err == nil {
 		serverPort = port
 	}
+
 	return
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -107,6 +107,7 @@ func DBNamespaceFromDSN(dsn string) (attribute.KeyValue, error) {
 	// [scheme://][user[:password]@][protocol([addr])][/path][?param1=value1&paramN=valueN]
 	// Find the schema part.
 	var scheme string
+
 	schemaIndex := strings.Index(dsn, "://")
 	if schemaIndex != -1 {
 		scheme = dsn[:schemaIndex]
@@ -133,6 +134,7 @@ func DBNamespaceFromDSN(dsn string) (attribute.KeyValue, error) {
 	// [protocol([addr])][/path]
 	// Find the '/' that separates the address part from the path (database or instance name).
 	pathIndex := strings.Index(dsn, "/")
+
 	var path string
 	if pathIndex != -1 {
 		path = dsn[pathIndex+1:]
@@ -141,16 +143,20 @@ func DBNamespaceFromDSN(dsn string) (attribute.KeyValue, error) {
 	if scheme == "oracle" {
 		return attribute.KeyValue{}, errDBNamespaceNotFound
 	}
+
 	if scheme == "sqlserver" {
 		if params, err := url.ParseQuery(queryString); err == nil {
 			if db := params.Get("database"); db != "" {
 				return semconv.DBNamespace(db), nil
 			}
 		}
+
 		return attribute.KeyValue{}, errDBNamespaceNotFound
 	}
+
 	if path == "" {
 		return attribute.KeyValue{}, errDBNamespaceNotFound
 	}
+
 	return semconv.DBNamespace(path), nil
 }

--- a/helpers.go
+++ b/helpers.go
@@ -60,40 +60,47 @@ func AttributesFromDSN(dsn string) []attribute.KeyValue {
 	}
 
 	// [protocol([addr])] or [addr]
-	// Find the '(' that starts the address part.
-	openParen := strings.Index(dsn, "(")
-	if openParen != -1 {
+	host, port := parseHostPort(dsn)
+
+	var attrs []attribute.KeyValue
+	if host != "" {
+		attrs = append(attrs, semconv.ServerAddress(host))
+	}
+	if port != -1 {
+		attrs = append(attrs, semconv.ServerPortKey.Int64(port))
+	}
+	return attrs
+}
+
+// parseHostPort extracts the server address and port from a DSN fragment.
+// It handles MySQL's protocol(addr) syntax where the address is wrapped in parentheses.
+// serverAddress is an empty string if not found; serverPort is -1 if not found.
+func parseHostPort(dsn string) (serverAddress string, serverPort int64) {
+	serverPort = -1
+
+	// Strip MySQL's protocol(addr) wrapper, e.g. "tcp(host:3306)" → "host:3306".
+	if openParen := strings.Index(dsn, "("); openParen != -1 {
 		rest := dsn[openParen+1:]
 		if closeParen := strings.Index(rest, ")"); closeParen != -1 {
 			rest = rest[:closeParen]
 		}
-		// Remove the protocol part from the DSN.
 		dsn = rest
 	}
 
-	// [addr]
 	if len(dsn) == 0 {
-		return nil
+		return
 	}
 
 	host, portStr, err := net.SplitHostPort(dsn)
 	if err != nil {
-		host = dsn
+		return dsn, serverPort
 	}
 
-	attrs := make([]attribute.KeyValue, 0, 2)
-	if host != "" {
-		attrs = append(attrs, semconv.ServerAddress(host))
+	serverAddress = host
+	if port, err := strconv.ParseInt(portStr, 10, 64); err == nil {
+		serverPort = port
 	}
-
-	if portStr != "" {
-		port, err := strconv.ParseInt(portStr, 10, 64)
-		if err == nil {
-			attrs = append(attrs, semconv.ServerPortKey.Int64(port))
-		}
-	}
-
-	return attrs
+	return
 }
 
 // errDBNamespaceNotFound is returned by [DBNamespaceFromDSN] when no database name can be extracted from the DSN.
@@ -140,23 +147,18 @@ func DBNamespaceFromDSN(dsn string) (attribute.KeyValue, error) {
 		path = dsn[pathIndex+1:]
 	}
 
-	if scheme == "oracle" {
-		return attribute.KeyValue{}, errDBNamespaceNotFound
-	}
-
-	if scheme == "sqlserver" {
+	switch scheme {
+	case "sqlserver", "mssql":
 		if params, err := url.ParseQuery(queryString); err == nil {
 			if db := params.Get("database"); db != "" {
 				return semconv.DBNamespace(db), nil
 			}
 		}
-
-		return attribute.KeyValue{}, errDBNamespaceNotFound
+	case "postgresql", "postgres", "mysql", "clickhouse":
+		if path != "" {
+			return semconv.DBNamespace(path), nil
+		}
 	}
 
-	if path == "" {
-		return attribute.KeyValue{}, errDBNamespaceNotFound
-	}
-
-	return semconv.DBNamespace(path), nil
+	return attribute.KeyValue{}, errDBNamespaceNotFound
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -162,7 +162,6 @@ func TestAttributesFromDSN(t *testing.T) {
 	}
 }
 
-//nolint:gosec
 func TestDBNamespaceFromDSN(t *testing.T) {
 	testCases := []struct {
 		dsn      string
@@ -226,7 +225,8 @@ func TestAttributesAndDBNamespaceFromDSN(t *testing.T) {
 				semconv.ServerAddress("example.com"),
 				semconv.DBNamespace("db"),
 				semconv.DBSystemNameMySQL,
-			}},
+			},
+		},
 		// Empty or missing db name
 		{
 			dsn:          "mysql://root:pass@example.com",
@@ -234,7 +234,8 @@ func TestAttributesAndDBNamespaceFromDSN(t *testing.T) {
 			expected: []attribute.KeyValue{
 				semconv.ServerAddress("example.com"),
 				semconv.DBSystemNameMySQL,
-			}},
+			},
+		},
 		//
 		// sqlserver: database from query param
 		{

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -22,7 +22,6 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
-//nolint:gosec
 func TestAttributesFromDSN(t *testing.T) {
 	testCases := []struct {
 		dsn      string
@@ -52,6 +51,13 @@ func TestAttributesFromDSN(t *testing.T) {
 			dsn: "mysql://root:otel_password@tcp(2001:db8:1234:5678:9abc:def0:0001)/db?parseTime=true",
 			expected: []attribute.KeyValue{
 				semconv.ServerAddress("2001:db8:1234:5678:9abc:def0:0001"),
+			},
+		},
+		{
+			dsn: "sqlserver://user:pass@dbhost:1433?database=db",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("dbhost"),
+				semconv.ServerPort(1433),
 			},
 		},
 		{
@@ -137,11 +143,126 @@ func TestAttributesFromDSN(t *testing.T) {
 				semconv.ServerAddress("tcp"),
 			},
 		},
+		{
+			// Missing closing protocol parenthesis and no path/queryString shouldn't cause a panic
+			dsn: "mysql://root:otel_password@tcp(example.com",
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.dsn, func(t *testing.T) {
 			got := AttributesFromDSN(tc.dsn)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+//nolint:gosec
+func TestDBNamespaceFromDSN(t *testing.T) {
+	testCases := []struct {
+		dsn      string
+		expected attribute.KeyValue
+		wantErr  bool
+	}{
+		// Standard URL-style DSNs
+		{dsn: "mysql://root:pass@example.com/db", expected: semconv.DBNamespace("db")},
+		{dsn: "mysql://root:pass@tcp(example.com)/db?parseTime=true", expected: semconv.DBNamespace("db")},
+		{dsn: "postgres://root:secret@0.0.0.0:42/db?param1=value1", expected: semconv.DBNamespace("db")},
+		{dsn: "unknown://user:pass@dbhost/db", expected: semconv.DBNamespace("db")},
+
+		// No scheme
+		{dsn: "root:secret@/db?parseTime=true", expected: semconv.DBNamespace("db")},
+		{dsn: "example.com/db", expected: semconv.DBNamespace("db")},
+		{dsn: "root:secret@tcp(mysql)/db?parseTime=true", expected: semconv.DBNamespace("db")},
+
+		// Empty or missing db name
+		{dsn: "example.com:3307", wantErr: true},
+		{dsn: "postgres://user:pass@dbhost/", wantErr: true},
+		{dsn: "sqlserver://user:pass@dbhost", wantErr: true},
+
+		// sqlserver: database from query param
+		{dsn: "sqlserver://user:pass@dbhost:1433?database=db", expected: semconv.DBNamespace("db")},
+		{dsn: "sqlserver://user:pass@dbhost/SQLEXPRESS?database=db", expected: semconv.DBNamespace("db")},
+		{dsn: "sqlserver://dbhost:1433?database=db", expected: semconv.DBNamespace("db")},
+
+		// sqlserver: no database query param
+		{dsn: "sqlserver://user:pass@dbhost/SQLEXPRESS", wantErr: true},
+		{dsn: "sqlserver://user:pass@dbhost:1433", wantErr: true},
+
+		// oracle: db namespace not supported
+		{dsn: "oracle://user:pass@dbhost:1521/service", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.dsn, func(t *testing.T) {
+			got, err := DBNamespaceFromDSN(tc.dsn)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}
+
+//nolint:gosec
+func TestAttributesAndDBNamespaceFromDSN(t *testing.T) {
+	testCases := []struct {
+		dsn          string
+		dbSystemName attribute.KeyValue
+		expected     []attribute.KeyValue
+	}{
+		// Standard URL-style DSNs
+		{
+			dsn:          "mysql://root:pass@example.com/db",
+			dbSystemName: semconv.DBSystemNameMySQL,
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+				semconv.DBNamespace("db"),
+				semconv.DBSystemNameMySQL,
+			}},
+		// Empty or missing db name
+		{
+			dsn:          "mysql://root:pass@example.com",
+			dbSystemName: semconv.DBSystemNameMySQL,
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("example.com"),
+				semconv.DBSystemNameMySQL,
+			}},
+		//
+		// sqlserver: database from query param
+		{
+			dsn:          "sqlserver://user:pass@dbhost:1433?database=db",
+			dbSystemName: semconv.DBSystemNameMicrosoftSQLServer,
+
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("dbhost"),
+				semconv.ServerPort(1433),
+				semconv.DBNamespace("db"),
+				semconv.DBSystemNameMicrosoftSQLServer,
+			}},
+		// sqlserver: missing db name
+		{
+			dsn:          "sqlserver://user:pass@dbhost/SQLEXPRESS",
+			dbSystemName: semconv.DBSystemNameMicrosoftSQLServer,
+
+			expected: []attribute.KeyValue{
+				semconv.ServerAddress("dbhost"),
+				semconv.DBSystemNameMicrosoftSQLServer,
+			}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.dsn, func(t *testing.T) {
+			got := AttributesFromDSN(tc.dsn)
+			if dbNamespace, err := DBNamespaceFromDSN(tc.dsn); err == nil {
+				got = append(got, dbNamespace)
+			}
+			got = append(got, tc.dbSystemName)
 			assert.Equal(t, tc.expected, got)
 		})
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -173,12 +173,12 @@ func TestDBNamespaceFromDSN(t *testing.T) {
 		{dsn: "mysql://root:pass@example.com/db", expected: semconv.DBNamespace("db")},
 		{dsn: "mysql://root:pass@tcp(example.com)/db?parseTime=true", expected: semconv.DBNamespace("db")},
 		{dsn: "postgres://root:secret@0.0.0.0:42/db?param1=value1", expected: semconv.DBNamespace("db")},
-		{dsn: "unknown://user:pass@dbhost/db", expected: semconv.DBNamespace("db")},
+		{dsn: "unknown://user:pass@dbhost/db", wantErr: true}, // unknown scheme: db.namespace not extracted
 
-		// No scheme
-		{dsn: "root:secret@/db?parseTime=true", expected: semconv.DBNamespace("db")},
-		{dsn: "example.com/db", expected: semconv.DBNamespace("db")},
-		{dsn: "root:secret@tcp(mysql)/db?parseTime=true", expected: semconv.DBNamespace("db")},
+		// No scheme: db.namespace not extracted
+		{dsn: "root:secret@/db?parseTime=true", wantErr: true},
+		{dsn: "example.com/db", wantErr: true},
+		{dsn: "root:secret@tcp(mysql)/db?parseTime=true", wantErr: true},
 
 		// Empty or missing db name
 		{dsn: "example.com:3307", wantErr: true},

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -244,7 +244,8 @@ func TestAttributesAndDBNamespaceFromDSN(t *testing.T) {
 				semconv.ServerPort(1433),
 				semconv.DBNamespace("db"),
 				semconv.DBSystemNameMicrosoftSQLServer,
-			}},
+			},
+		},
 		// sqlserver: missing db name
 		{
 			dsn:          "sqlserver://user:pass@dbhost/SQLEXPRESS",
@@ -253,7 +254,8 @@ func TestAttributesAndDBNamespaceFromDSN(t *testing.T) {
 			expected: []attribute.KeyValue{
 				semconv.ServerAddress("dbhost"),
 				semconv.DBSystemNameMicrosoftSQLServer,
-			}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -262,6 +264,7 @@ func TestAttributesAndDBNamespaceFromDSN(t *testing.T) {
 			if dbNamespace, err := DBNamespaceFromDSN(tc.dsn); err == nil {
 				got = append(got, dbNamespace)
 			}
+
 			got = append(got, tc.dbSystemName)
 			assert.Equal(t, tc.expected, got)
 		})

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -18,10 +18,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
+//nolint:gosec
 func TestAttributesFromDSN(t *testing.T) {
 	testCases := []struct {
 		dsn      string
@@ -202,7 +204,7 @@ func TestDBNamespaceFromDSN(t *testing.T) {
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.expected, got)
 			}
 		})

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -162,6 +162,7 @@ func TestAttributesFromDSN(t *testing.T) {
 	}
 }
 
+//nolint:gosec
 func TestDBNamespaceFromDSN(t *testing.T) {
 	testCases := []struct {
 		dsn      string

--- a/utils_test.go
+++ b/utils_test.go
@@ -250,6 +250,7 @@ func prepareMetrics() (sdkmetric.Reader, *sdkmetric.MeterProvider) {
 
 func getDummyAttributesGetter() AttributesGetter {
 	return func(_ context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+		//nolint:prealloc
 		attrs := []attribute.KeyValue{
 			attribute.String("method", string(method)),
 			attribute.String("query", query),

--- a/utils_test.go
+++ b/utils_test.go
@@ -250,7 +250,7 @@ func prepareMetrics() (sdkmetric.Reader, *sdkmetric.MeterProvider) {
 
 func getDummyAttributesGetter() AttributesGetter {
 	return func(_ context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
-		//nolint:gosec
+		//nolint:prealloc
 		attrs := []attribute.KeyValue{
 			attribute.String("method", string(method)),
 			attribute.String("query", query),

--- a/utils_test.go
+++ b/utils_test.go
@@ -250,7 +250,7 @@ func prepareMetrics() (sdkmetric.Reader, *sdkmetric.MeterProvider) {
 
 func getDummyAttributesGetter() AttributesGetter {
 	return func(_ context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
-		//nolint:prealloc
+		//nolint:gosec
 		attrs := []attribute.KeyValue{
 			attribute.String("method", string(method)),
 			attribute.String("query", query),

--- a/utils_test.go
+++ b/utils_test.go
@@ -250,7 +250,6 @@ func prepareMetrics() (sdkmetric.Reader, *sdkmetric.MeterProvider) {
 
 func getDummyAttributesGetter() AttributesGetter {
 	return func(_ context.Context, method Method, query string, args []driver.NamedValue) []attribute.KeyValue {
-		//nolint:prealloc
 		attrs := []attribute.KeyValue{
 			attribute.String("method", string(method)),
 			attribute.String("query", query),


### PR DESCRIPTION
## Summary


I explore 2 solutions to add `db.namespace`. 

In all cases, we extract `db.namespace` only for well-known DSN patterns to avoid mapping it to incorrect values. Well-known DSN patterns: “postgresql”, “postgres”, “mysql”, “clickhouse”, “sqlserver”, or “mssql”.

Solutions:

* In this PR, we introduce an additional helper function `DBNamespaceFromDSN`, and users have to change their code to benefit of this improvement. New code style looks like:

   ```go
	attrs := append(otelsql.AttributesFromDSN(mysqlDSN), semconv.DBSystemNameMySQL)

	if dbNamespace, err := otelsql.DBNamespaceFromDSN(mysqlDSN); err == nil {
		attrs = append(attrs, dbNamespace)
	}

	db, err := otelsql.Open("mysql", mysqlDSN, otelsql.WithAttributes(attrs...,))
   ```

* In PR #608, `db.namespace` is parsed in the `AttributesFromDSN` function, no code change for users to benefit of it. Code style remains:

   ```go
	attrs := append(otelsql.AttributesFromDSN(mysqlDSN), semconv.DBSystemNameMySQL)

	db, err := otelsql.Open("mysql", mysqlDSN, otelsql.WithAttributes(attrs...,))
   ```



## PR Summary

Add `DBNamespaceFromDSN` helper and fix `AttributesFromDSN` bugs

* Introduce `DBNamespaceFromDSN` to extract the `db.namespace` OTel attribute
from a DSN string, with support for Microsoft sqlserver (database query param) and
an explicit error for oracle (DB_UNIQUE_NAME is not DSN-derivable).
* Fix a panic in `AttributesFromDSN` when the closing protocol
parenthesis is missing and the DSN has no path nor query string, 
* fix `server.port` parsing when the DSN has a query string but no path.