### PR TITLE
Multiple performance improvements

### DIFF
--- a/config.go
+++ b/config.go
@@ -143,14 +143,14 @@ func defaultSpanNameFormatter(_ context.Context, method Method, _ string) string
 }
 
 // newConfig returns a config with all Options set.
-func newConfig(options ...Option) config {
-	cfg := config{
+func newConfig(options ...Option) *config {
+	cfg := &config{
 		TracerProvider:    otel.GetTracerProvider(),
 		MeterProvider:     otel.GetMeterProvider(),
 		SpanNameFormatter: defaultSpanNameFormatter,
 	}
 	for _, opt := range options {
-		opt.Apply(&cfg)
+		opt.Apply(cfg)
 	}
 
 	cfg.Tracer = cfg.TracerProvider.Tracer(

--- a/config.go
+++ b/config.go
@@ -54,6 +54,9 @@ type config struct {
 	MeterProvider metric.MeterProvider
 	Meter         metric.Meter
 
+	// metricMethodAttrs holds the precomputed base attributes per Method.
+	metricMethodAttrs map[Method]methodMetricAttributes
+
 	Instruments *instruments
 
 	SpanOptions SpanOptions
@@ -169,5 +172,22 @@ func newConfig(options ...Option) *config {
 		otel.Handle(err)
 	}
 
+	cfg.metricMethodAttrs = buildMethodAttributes(cfg.Attributes)
+
 	return cfg
+}
+
+func buildMethodAttributes(base []attribute.KeyValue) map[Method]methodMetricAttributes {
+	out := make(map[Method]methodMetricAttributes, len(allMethods))
+
+	for _, m := range allMethods {
+		attrs := getMethodAttributes(m, base)
+
+		out[m] = methodMetricAttributes{
+			attrs: attrs,
+			set:   attribute.NewSet(attrs...),
+		}
+	}
+
+	return out
 }

--- a/config_test.go
+++ b/config_test.go
@@ -39,7 +39,7 @@ func TestNewConfig(t *testing.T) {
 	// Ignore function compares for test equality check
 	cfg.SpanNameFormatter = nil
 
-	assert.Equal(t, config{
+	assert.Equal(t, &config{
 		TracerProvider: otel.GetTracerProvider(),
 		Tracer: otel.GetTracerProvider().Tracer(
 			instrumentationName,

--- a/config_test.go
+++ b/config_test.go
@@ -52,7 +52,9 @@ func TestNewConfig(t *testing.T) {
 		),
 		// No need to check values of instruments in this part.
 		Instruments: cfg.Instruments,
-		SpanOptions: SpanOptions{Ping: true},
+		// No need to check values of metricBase in this part.
+		metricMethodAttrs: cfg.metricMethodAttrs,
+		SpanOptions:       SpanOptions{Ping: true},
 		Attributes: []attribute.KeyValue{
 			semconv.DBSystemNameMySQL,
 		},

--- a/conn.go
+++ b/conn.go
@@ -57,25 +57,17 @@ func (c *otConn) Ping(ctx context.Context) (err error) {
 	}
 
 	method := MethodConnPing
-	onDefer := recordMetric(ctx, c.cfg.Instruments, c.cfg, method, "", nil)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.Record(c.cfg, method, &err)
 
 	if c.cfg.SpanOptions.Ping {
 		if filterSpan(ctx, c.cfg.SpanOptions, method, "", nil) {
 			var span trace.Span
 
 			ctx, span = createSpan(ctx, c.cfg, method, false, "", nil)
-
-			defer func() {
-				if err != nil {
-					recordSpanError(span, c.cfg.SpanOptions, err)
-				}
-
-				span.End()
-			}()
+			defer span.End()
+			defer recordSpanErrorDeferred(span, c.cfg.SpanOptions, &err)
 		}
 	}
 
@@ -102,11 +94,9 @@ func (c *otConn) ExecContext(
 	}
 
 	method := MethodConnExec
-	onDefer := recordMetric(ctx, c.cfg.Instruments, c.cfg, method, query, args)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.Record(c.cfg, method, &err)
 
 	var span trace.Span
 	if filterSpan(ctx, c.cfg.SpanOptions, method, query, args) {
@@ -141,11 +131,9 @@ func (c *otConn) QueryContext(
 	}
 
 	method := MethodConnQuery
-	onDefer := recordMetric(ctx, c.cfg.Instruments, c.cfg, method, query, args)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.RecordQuery(c.cfg, method, query, args, &err)
 
 	var span trace.Span
 
@@ -166,11 +154,9 @@ func (c *otConn) QueryContext(
 
 func (c *otConn) PrepareContext(ctx context.Context, query string) (stmt driver.Stmt, err error) {
 	method := MethodConnPrepare
-	onDefer := recordMetric(ctx, c.cfg.Instruments, c.cfg, method, query, nil)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.RecordQuery(c.cfg, method, query, nil, &err)
 
 	var span trace.Span
 	if !c.cfg.SpanOptions.OmitConnPrepare && filterSpan(ctx, c.cfg.SpanOptions, method, query, nil) {
@@ -203,11 +189,9 @@ func (c *otConn) PrepareContext(ctx context.Context, query string) (stmt driver.
 
 func (c *otConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.Tx, err error) {
 	method := MethodConnBeginTx
-	onDefer := recordMetric(ctx, c.cfg.Instruments, c.cfg, method, "", nil)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.Record(c.cfg, method, &err)
 
 	var beginTxCtx context.Context
 
@@ -265,11 +249,9 @@ func (c *otConn) ResetSession(ctx context.Context) (err error) {
 	}
 
 	method := MethodConnResetSession
-	onDefer := recordMetric(ctx, c.cfg.Instruments, c.cfg, method, "", nil)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.Record(c.cfg, method, &err)
 
 	var span trace.Span
 	if !c.cfg.SpanOptions.OmitConnResetSession && filterSpan(ctx, c.cfg.SpanOptions, method, "", nil) {

--- a/conn.go
+++ b/conn.go
@@ -39,10 +39,10 @@ var (
 
 type otConn struct {
 	driver.Conn
-	cfg config
+	cfg *config
 }
 
-func newConn(conn driver.Conn, cfg config) *otConn {
+func newConn(conn driver.Conn, cfg *config) *otConn {
 	return &otConn{
 		Conn: conn,
 		cfg:  cfg,

--- a/conn_bench_test.go
+++ b/conn_bench_test.go
@@ -1,0 +1,111 @@
+// Copyright Sam Xie
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsql
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+)
+
+func BenchmarkConnQueryContext(b *testing.B) {
+	for name, newCfg := range benchMarkConfigs {
+		b.Run(name, func(b *testing.B) {
+			cfg := newCfg()
+			conn := newConn(benchConn{}, cfg)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					rows, err := conn.QueryContext(ctx, "SELECT 1", nil)
+					if err != nil {
+						b.Fatal(err)
+					}
+
+					if err := rows.Close(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkConnExecContext(b *testing.B) {
+	for name, newCfg := range benchMarkConfigs {
+		b.Run(name, func(b *testing.B) {
+			cfg := newCfg()
+			conn := newConn(benchConn{}, cfg)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					if _, err := conn.ExecContext(ctx, "UPDATE x SET y=1", nil); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkConnResetSession(b *testing.B) {
+	for name, newCfg := range benchMarkConfigs {
+		b.Run(name, func(b *testing.B) {
+			cfg := newCfg()
+			conn := newConn(benchConn{}, cfg)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					if err := conn.ResetSession(ctx); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkConnBeginTx(b *testing.B) {
+	for name, newCfg := range benchMarkConfigs {
+		b.Run(name, func(b *testing.B) {
+			cfg := newCfg()
+			conn := newConn(benchConn{}, cfg)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					tx, err := conn.BeginTx(ctx, driver.TxOptions{})
+					if err != nil {
+						b.Fatal(err)
+					}
+
+					if err := tx.Commit(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -862,7 +862,7 @@ func TestOtConn_ResetSession(t *testing.T) {
 func TestOtConn_IsValid(t *testing.T) {
 	t.Run("delegates to underlying conn", func(t *testing.T) {
 		mc := &mockValidatorConn{valid: true}
-		conn := newConn(mc, config{})
+		conn := newConn(mc, &config{})
 		assert.True(t, conn.IsValid())
 
 		mc.valid = false
@@ -872,7 +872,7 @@ func TestOtConn_IsValid(t *testing.T) {
 
 	t.Run("returns true when underlying conn does not implement Validator", func(t *testing.T) {
 		mc := newMockConn(false)
-		conn := newConn(mc, config{})
+		conn := newConn(mc, &config{})
 		assert.True(t, conn.IsValid())
 	})
 }
@@ -890,7 +890,7 @@ var _ driver.Validator = (*mockValidatorConn)(nil)
 
 func TestOtConn_Raw(t *testing.T) {
 	raw := newMockConn(false)
-	conn := newConn(raw, config{})
+	conn := newConn(raw, &config{})
 
 	assert.Equal(t, raw, conn.Raw())
 }

--- a/connector.go
+++ b/connector.go
@@ -43,11 +43,9 @@ func newConnector(connector driver.Connector, otDriver *otDriver) *otConnector {
 
 func (c *otConnector) Connect(ctx context.Context) (connection driver.Conn, err error) {
 	method := MethodConnectorConnect
-	onDefer := recordMetric(ctx, c.cfg.Instruments, c.cfg, method, "", nil)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.Record(c.cfg, method, &err)
 
 	var span trace.Span
 	if !c.cfg.SpanOptions.OmitConnectorConnect && filterSpan(ctx, c.cfg.SpanOptions, method, "", nil) {

--- a/connector.go
+++ b/connector.go
@@ -30,7 +30,7 @@ var (
 type otConnector struct {
 	driver.Connector
 	otDriver *otDriver
-	cfg      config
+	cfg      *config
 }
 
 func newConnector(connector driver.Connector, otDriver *otDriver) *otConnector {

--- a/driver.go
+++ b/driver.go
@@ -23,10 +23,10 @@ var (
 
 type otDriver struct {
 	driver driver.Driver
-	cfg    config
+	cfg    *config
 }
 
-func newDriver(dri driver.Driver, cfg config) driver.Driver {
+func newDriver(dri driver.Driver, cfg *config) driver.Driver {
 	if _, ok := dri.(driver.DriverContext); ok {
 		return newOtDriver(dri, cfg)
 	}
@@ -34,7 +34,7 @@ func newDriver(dri driver.Driver, cfg config) driver.Driver {
 	return struct{ driver.Driver }{newOtDriver(dri, cfg)}
 }
 
-func newOtDriver(dri driver.Driver, cfg config) *otDriver {
+func newOtDriver(dri driver.Driver, cfg *config) *otDriver {
 	return &otDriver{driver: dri, cfg: cfg}
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -69,12 +69,12 @@ var (
 )
 
 func TestNewDriver(t *testing.T) {
-	d := newDriver(newMockDriver(false), config{Attributes: []attribute.KeyValue{semconv.DBSystemNameMySQL}})
+	d := newDriver(newMockDriver(false), &config{Attributes: []attribute.KeyValue{semconv.DBSystemNameMySQL}})
 
 	otelDriver, ok := d.(*otDriver)
 	require.True(t, ok)
 	assert.Equal(t, newMockDriver(false), otelDriver.driver)
-	assert.Equal(t, config{Attributes: []attribute.KeyValue{semconv.DBSystemNameMySQL}}, otelDriver.cfg)
+	assert.Equal(t, &config{Attributes: []attribute.KeyValue{semconv.DBSystemNameMySQL}}, otelDriver.cfg)
 }
 
 func TestOtDriver_Open(t *testing.T) {
@@ -94,7 +94,7 @@ func TestOtDriver_Open(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			md := newMockDriver(tc.error)
-			d := newDriver(md, config{})
+			d := newDriver(md, &config{})
 
 			conn, err := d.Open("test")
 
@@ -129,7 +129,7 @@ func TestOtDriver_OpenConnector(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			md := newMockDriver(tc.error)
-			d := newDriver(md, config{})
+			d := newDriver(md, &config{})
 
 			otelDriver, ok := d.(*otDriver)
 			require.True(t, ok)

--- a/legacy_conn_test.go
+++ b/legacy_conn_test.go
@@ -90,13 +90,13 @@ func newMockLegacyConn(shouldError bool) *mockLegacyConn {
 }
 
 func TestOtConn_PingWithLegacyConn(t *testing.T) {
-	otelConn := newConn(newMockLegacyConn(false), config{})
+	otelConn := newConn(newMockLegacyConn(false), &config{})
 	err := otelConn.Ping(context.Background())
 	assert.NoError(t, err)
 }
 
 func TestOtConn_ResetSessionWithLegacyConn(t *testing.T) {
-	otelConn := newConn(newMockLegacyConn(false), config{})
+	otelConn := newConn(newMockLegacyConn(false), &config{})
 	err := otelConn.ResetSession(context.Background())
 	assert.NoError(t, err)
 }

--- a/methods.go
+++ b/methods.go
@@ -14,6 +14,11 @@
 
 package otelsql
 
+import (
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+)
+
 // Method specifics operation in the database/sql package.
 type Method string
 
@@ -51,3 +56,32 @@ const (
 	// EventRowsNext is triggered during driver.Rows.Next iteration to track each row fetching operation.
 	EventRowsNext Event = "sql.rows.next"
 )
+
+var allMethods = []Method{
+	MethodConnectorConnect,
+	MethodConnPing,
+	MethodConnExec,
+	MethodConnQuery,
+	MethodConnPrepare,
+	MethodConnBeginTx,
+	MethodConnResetSession,
+	MethodTxCommit,
+	MethodTxRollback,
+	MethodStmtExec,
+	MethodStmtQuery,
+	MethodRows,
+}
+
+func getMethodAttributes(method Method, base []attribute.KeyValue) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(base)+1)
+	attrs = append(attrs, base...)
+	attrs = append(attrs, semconv.DBOperationName(string(method)))
+
+	return attrs
+}
+
+// methodMetricAttributes holds the precomputed base attributes for a Method.
+type methodMetricAttributes struct {
+	attrs []attribute.KeyValue
+	set   attribute.Set
+}

--- a/mock_bench_test.go
+++ b/mock_bench_test.go
@@ -1,0 +1,136 @@
+// Copyright Sam Xie
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsql
+
+import (
+	"context"
+	"database/sql/driver"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Stateless driver mocks used only for benchmarks. They allocate nothing and are
+// safe for concurrent use.
+// This allows benchmarks measure otelsql's wrapper overhead.
+
+type benchConn struct{}
+
+func (benchConn) Begin() (driver.Tx, error)           { return benchTx{}, nil }
+func (benchConn) Close() error                        { return nil }
+func (benchConn) Prepare(string) (driver.Stmt, error) { return benchStmt{}, nil }
+func (benchConn) Ping(context.Context) error          { return nil }
+func (benchConn) ResetSession(context.Context) error  { return nil }
+
+func (benchConn) PrepareContext(context.Context, string) (driver.Stmt, error) {
+	return benchStmt{}, nil
+}
+
+func (benchConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	return benchResult{}, nil
+}
+
+func (benchConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return benchRows{}, nil
+}
+
+func (benchConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	return benchTx{}, nil
+}
+
+type benchStmt struct{}
+
+func (benchStmt) Close() error                               { return nil }
+func (benchStmt) NumInput() int                              { return 0 }
+func (benchStmt) Exec([]driver.Value) (driver.Result, error) { return benchResult{}, nil }
+func (benchStmt) Query([]driver.Value) (driver.Rows, error)  { return benchRows{}, nil }
+func (benchStmt) CheckNamedValue(*driver.NamedValue) error   { return nil }
+func (benchStmt) ColumnConverter(int) driver.ValueConverter  { return driver.DefaultParameterConverter }
+
+func (benchStmt) ExecContext(context.Context, []driver.NamedValue) (driver.Result, error) {
+	return benchResult{}, nil
+}
+
+func (benchStmt) QueryContext(context.Context, []driver.NamedValue) (driver.Rows, error) {
+	return benchRows{}, nil
+}
+
+type benchRows struct{}
+
+func (benchRows) Columns() []string           { return nil }
+func (benchRows) Close() error                { return nil }
+func (benchRows) Next(_ []driver.Value) error { return nil }
+
+type benchTx struct{}
+
+func (benchTx) Commit() error   { return nil }
+func (benchTx) Rollback() error { return nil }
+
+type benchResult struct{}
+
+func (benchResult) LastInsertId() (int64, error) { return 0, nil }
+func (benchResult) RowsAffected() (int64, error) { return 0, nil }
+
+var (
+	_ driver.Conn               = benchConn{}
+	_ driver.Pinger             = benchConn{}
+	_ driver.ExecerContext      = benchConn{}
+	_ driver.QueryerContext     = benchConn{}
+	_ driver.ConnPrepareContext = benchConn{}
+	_ driver.ConnBeginTx        = benchConn{}
+	_ driver.SessionResetter    = benchConn{}
+
+	_ driver.Stmt              = benchStmt{}
+	_ driver.StmtExecContext   = benchStmt{}
+	_ driver.StmtQueryContext  = benchStmt{}
+	_ driver.NamedValueChecker = benchStmt{}
+
+	_ driver.Rows   = benchRows{}
+	_ driver.Tx     = benchTx{}
+	_ driver.Result = benchResult{}
+)
+
+// benchAttrs mimics a small base attribute set typical in production
+// (service identity + db identity). With 3 attributes the per-call cost of
+// copying cfg.Attributes is visible without dominating the benchmark.
+var benchAttrs = []attribute.KeyValue{
+	attribute.String("service.name", "bench"),
+	attribute.String("db.system.name", "mysql"),
+	attribute.String("db.namespace", "test"),
+}
+
+func newBenchConfig() config {
+	cfg := newConfig()
+	cfg.Tracer = sdktrace.NewTracerProvider().Tracer("benchmark")
+	// Use a fixed-capacity slice so cfg.Attributes header stays stable across
+	// the benchmark and matches the production pattern (set once at startup).
+	cfg.Attributes = make([]attribute.KeyValue, 0, len(benchAttrs))
+	cfg.Attributes = append(cfg.Attributes, benchAttrs...)
+
+	return cfg
+}
+
+func newBenchConfigNeverSample() config {
+	cfg := newBenchConfig()
+	cfg.Tracer = sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.NeverSample())).
+		Tracer("benchmark")
+
+	return cfg
+}
+
+var benchMarkConfigs = map[string]func() config{
+	"Default":     newBenchConfig,
+	"NeverSample": newBenchConfigNeverSample,
+}

--- a/mock_bench_test.go
+++ b/mock_bench_test.go
@@ -111,7 +111,7 @@ var benchAttrs = []attribute.KeyValue{
 	attribute.String("db.namespace", "test"),
 }
 
-func newBenchConfig() config {
+func newBenchConfig() *config {
 	cfg := newConfig()
 	cfg.Tracer = sdktrace.NewTracerProvider().Tracer("benchmark")
 	// Use a fixed-capacity slice so cfg.Attributes header stays stable across
@@ -122,7 +122,7 @@ func newBenchConfig() config {
 	return cfg
 }
 
-func newBenchConfigNeverSample() config {
+func newBenchConfigNeverSample() *config {
 	cfg := newBenchConfig()
 	cfg.Tracer = sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.NeverSample())).
 		Tracer("benchmark")
@@ -130,7 +130,7 @@ func newBenchConfigNeverSample() config {
 	return cfg
 }
 
-var benchMarkConfigs = map[string]func() config{
+var benchMarkConfigs = map[string]func() *config{
 	"Default":     newBenchConfig,
 	"NeverSample": newBenchConfigNeverSample,
 }

--- a/rows.go
+++ b/rows.go
@@ -35,33 +35,31 @@ var (
 type otRows struct {
 	driver.Rows
 
-	span    trace.Span
-	cfg     *config
-	onClose func(err error)
+	cfg    *config
+	span   trace.Span
+	metric durationMetric
 }
 
 func newRows(ctx context.Context, rows driver.Rows, cfg *config) *otRows {
 	var span trace.Span
 
 	method := MethodRows
-	onClose := recordMetric(ctx, cfg.Instruments, cfg, method, "", nil)
-
 	if !cfg.SpanOptions.OmitRows && filterSpan(ctx, cfg.SpanOptions, method, "", nil) {
 		_, span = createSpan(ctx, cfg, method, false, "", nil)
 	}
 
 	return &otRows{
-		Rows:    rows,
-		span:    span,
-		cfg:     cfg,
-		onClose: onClose,
+		Rows:   rows,
+		cfg:    cfg,
+		span:   span,
+		metric: startDurationMetric(ctx),
 	}
 }
 
 // HasNextResultSet calls the implements the driver.RowsNextResultSet for otRows.
 // It returns the underlying result of HasNextResultSet from the otRows.parent
 // if the parent implements driver.RowsNextResultSet.
-func (r otRows) HasNextResultSet() bool {
+func (r *otRows) HasNextResultSet() bool {
 	if v, ok := r.Rows.(driver.RowsNextResultSet); ok {
 		return v.HasNextResultSet()
 	}
@@ -72,7 +70,7 @@ func (r otRows) HasNextResultSet() bool {
 // NextResultSet calls the implements the driver.RowsNextResultSet for otRows.
 // It returns the underlying result of NextResultSet from the otRows.parent
 // if the parent implements driver.RowsNextResultSet.
-func (r otRows) NextResultSet() error {
+func (r *otRows) NextResultSet() error {
 	if v, ok := r.Rows.(driver.RowsNextResultSet); ok {
 		return v.NextResultSet()
 	}
@@ -83,7 +81,7 @@ func (r otRows) NextResultSet() error {
 // ColumnTypeDatabaseTypeName calls the implements the driver.RowsColumnTypeDatabaseTypeName for otRows.
 // It returns the underlying result of ColumnTypeDatabaseTypeName from the otRows.Rows
 // if the Rows implements driver.RowsColumnTypeDatabaseTypeName.
-func (r otRows) ColumnTypeDatabaseTypeName(index int) string {
+func (r *otRows) ColumnTypeDatabaseTypeName(index int) string {
 	if v, ok := r.Rows.(driver.RowsColumnTypeDatabaseTypeName); ok {
 		return v.ColumnTypeDatabaseTypeName(index)
 	}
@@ -94,7 +92,7 @@ func (r otRows) ColumnTypeDatabaseTypeName(index int) string {
 // ColumnTypeLength calls the implements the driver.RowsColumnTypeLength for otRows.
 // It returns the underlying result of ColumnTypeLength from the otRows.Rows
 // if the Rows implements driver.RowsColumnTypeLength.
-func (r otRows) ColumnTypeLength(index int) (length int64, ok bool) {
+func (r *otRows) ColumnTypeLength(index int) (length int64, ok bool) {
 	if v, ok := r.Rows.(driver.RowsColumnTypeLength); ok {
 		return v.ColumnTypeLength(index)
 	}
@@ -105,7 +103,7 @@ func (r otRows) ColumnTypeLength(index int) (length int64, ok bool) {
 // ColumnTypeNullable calls the implements the driver.RowsColumnTypeNullable for otRows.
 // It returns the underlying result of ColumnTypeNullable from the otRows.Rows
 // if the Rows implements driver.RowsColumnTypeNullable.
-func (r otRows) ColumnTypeNullable(index int) (nullable, ok bool) {
+func (r *otRows) ColumnTypeNullable(index int) (nullable, ok bool) {
 	if v, ok := r.Rows.(driver.RowsColumnTypeNullable); ok {
 		return v.ColumnTypeNullable(index)
 	}
@@ -116,7 +114,7 @@ func (r otRows) ColumnTypeNullable(index int) (nullable, ok bool) {
 // ColumnTypePrecisionScale calls the implements the driver.RowsColumnTypePrecisionScale for otRows.
 // It returns the underlying result of ColumnTypePrecisionScale from the otRows.Rows
 // if the Rows implements driver.RowsColumnTypePrecisionScale.
-func (r otRows) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
+func (r *otRows) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
 	if v, ok := r.Rows.(driver.RowsColumnTypePrecisionScale); ok {
 		return v.ColumnTypePrecisionScale(index)
 	}
@@ -124,24 +122,22 @@ func (r otRows) ColumnTypePrecisionScale(index int) (precision, scale int64, ok 
 	return 0, 0, false
 }
 
-func (r otRows) Close() (err error) {
-	defer func() {
-		if r.span != nil {
-			r.span.End()
+func (r *otRows) Close() error {
+	err := r.Rows.Close()
+	if r.span != nil {
+		if err != nil {
+			recordSpanError(r.span, r.cfg.SpanOptions, err)
 		}
 
-		r.onClose(err)
-	}()
-
-	err = r.Rows.Close()
-	if err != nil {
-		recordSpanError(r.span, r.cfg.SpanOptions, err)
+		r.span.End()
 	}
 
-	return
+	r.metric.Record(r.cfg, MethodRows, &err)
+
+	return err
 }
 
-func (r otRows) Next(dest []driver.Value) (err error) {
+func (r *otRows) Next(dest []driver.Value) (err error) {
 	if r.cfg.SpanOptions.RowsNext && r.span != nil {
 		r.span.AddEvent(string(EventRowsNext))
 	}

--- a/rows.go
+++ b/rows.go
@@ -36,11 +36,11 @@ type otRows struct {
 	driver.Rows
 
 	span    trace.Span
-	cfg     config
+	cfg     *config
 	onClose func(err error)
 }
 
-func newRows(ctx context.Context, rows driver.Rows, cfg config) *otRows {
+func newRows(ctx context.Context, rows driver.Rows, cfg *config) *otRows {
 	var span trace.Span
 
 	method := MethodRows

--- a/rows_bench_test.go
+++ b/rows_bench_test.go
@@ -1,0 +1,91 @@
+// Copyright Sam Xie
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsql
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+)
+
+func BenchmarkNewRows(b *testing.B) {
+	cfg := newBenchConfigNeverSample()
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		_ = newRows(ctx, benchRows{}, cfg)
+	}
+}
+
+func BenchmarkRows_Next(b *testing.B) {
+	configs := make(map[string]config, len(benchMarkConfigs))
+	for name, cfg := range benchMarkConfigs {
+		configs[name] = cfg()
+	}
+
+	configs["DefaultWithRowsNextEvent"] = func() config {
+		cfg := newBenchConfig()
+		cfg.SpanOptions.RowsNext = true
+
+		return cfg
+	}()
+
+	for name, cfg := range configs {
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				// Each goroutine works on its own rows handle, matching how a real
+				// caller would iterate a result set. newRows is amortized over many
+				// Next() calls, so its construction cost is not what's reported here.
+				rows := newRows(ctx, benchRows{}, cfg)
+
+				dest := make([]driver.Value, 0)
+				for pb.Next() {
+					if err := rows.Next(dest); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				_ = rows.Close()
+			})
+		})
+	}
+}
+
+func BenchmarkRows_Close(b *testing.B) {
+	for name, newCfg := range benchMarkConfigs {
+		b.Run(name, func(b *testing.B) {
+			cfg := newCfg()
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					rows := newRows(ctx, benchRows{}, cfg)
+					if err := rows.Close(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}

--- a/rows_bench_test.go
+++ b/rows_bench_test.go
@@ -33,12 +33,12 @@ func BenchmarkNewRows(b *testing.B) {
 }
 
 func BenchmarkRows_Next(b *testing.B) {
-	configs := make(map[string]config, len(benchMarkConfigs))
+	configs := make(map[string]*config, len(benchMarkConfigs))
 	for name, cfg := range benchMarkConfigs {
 		configs[name] = cfg()
 	}
 
-	configs["DefaultWithRowsNextEvent"] = func() config {
+	configs["DefaultWithRowsNextEvent"] = func() *config {
 		cfg := newBenchConfig()
 		cfg.SpanOptions.RowsNext = true
 

--- a/sql.go
+++ b/sql.go
@@ -158,7 +158,7 @@ func RegisterDBStatsMetrics(db *sql.DB, opts ...Option) (metric.Registration, er
 }
 
 func recordDBStatsMetrics(
-	dbStats sql.DBStats, instruments *dbStatsInstruments, cfg config, observer metric.Observer,
+	dbStats sql.DBStats, instruments *dbStatsInstruments, cfg *config, observer metric.Observer,
 ) {
 	observer.ObserveInt64(instruments.connectionMaxOpen,
 		int64(dbStats.MaxOpenConnections),

--- a/stmt.go
+++ b/stmt.go
@@ -30,13 +30,13 @@ var (
 
 type otStmt struct {
 	driver.Stmt
-	cfg config
+	cfg *config
 
 	query  string
 	otConn *otConn
 }
 
-func newStmt(stmt driver.Stmt, cfg config, query string, otConn *otConn) *otStmt {
+func newStmt(stmt driver.Stmt, cfg *config, query string, otConn *otConn) *otStmt {
 	return &otStmt{
 		Stmt:   stmt,
 		cfg:    cfg,

--- a/stmt.go
+++ b/stmt.go
@@ -49,11 +49,9 @@ func (s *otStmt) ExecContext(
 	ctx context.Context, args []driver.NamedValue,
 ) (result driver.Result, err error) {
 	method := MethodStmtExec
-	onDefer := recordMetric(ctx, s.cfg.Instruments, s.cfg, method, s.query, args)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.RecordQuery(s.cfg, method, s.query, args, &err)
 
 	var span trace.Span
 	if filterSpan(ctx, s.cfg.SpanOptions, method, s.query, args) {
@@ -87,11 +85,9 @@ func (s *otStmt) QueryContext(
 	ctx context.Context, args []driver.NamedValue,
 ) (rows driver.Rows, err error) {
 	method := MethodStmtQuery
-	onDefer := recordMetric(ctx, s.cfg.Instruments, s.cfg, method, s.query, args)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(ctx)
+	defer metric.RecordQuery(s.cfg, method, s.query, args, &err)
 
 	var span trace.Span
 

--- a/stmt_bench_test.go
+++ b/stmt_bench_test.go
@@ -1,0 +1,79 @@
+// Copyright Sam Xie
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsql
+
+import (
+	"context"
+	"testing"
+)
+
+func BenchmarkNewStmt(b *testing.B) {
+	cfg := newBenchConfigNeverSample()
+	conn := newConn(benchConn{}, cfg)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_ = newStmt(benchStmt{}, cfg, "SELECT 1", conn)
+	}
+}
+
+func BenchmarkStmtExecContext(b *testing.B) {
+	for name, newCfg := range benchMarkConfigs {
+		b.Run(name, func(b *testing.B) {
+			cfg := newCfg()
+			conn := newConn(benchConn{}, cfg)
+			stmt := newStmt(benchStmt{}, cfg, "INSERT INTO x VALUES (?)", conn)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					if _, err := stmt.ExecContext(ctx, nil); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkStmtQueryContext(b *testing.B) {
+	for name, newCfg := range benchMarkConfigs {
+		b.Run(name, func(b *testing.B) {
+			cfg := newCfg()
+			conn := newConn(benchConn{}, cfg)
+			stmt := newStmt(benchStmt{}, cfg, "SELECT * FROM x WHERE id = ?", conn)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					rows, err := stmt.QueryContext(ctx, nil)
+					if err != nil {
+						b.Fatal(err)
+					}
+
+					if err := rows.Close(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}

--- a/tx.go
+++ b/tx.go
@@ -26,10 +26,10 @@ var _ driver.Tx = (*otTx)(nil)
 type otTx struct {
 	tx  driver.Tx
 	ctx context.Context
-	cfg config
+	cfg *config
 }
 
-func newTx(ctx context.Context, tx driver.Tx, cfg config) *otTx {
+func newTx(ctx context.Context, tx driver.Tx, cfg *config) *otTx {
 	return &otTx{
 		tx:  tx,
 		ctx: ctx,

--- a/tx.go
+++ b/tx.go
@@ -39,11 +39,9 @@ func newTx(ctx context.Context, tx driver.Tx, cfg *config) *otTx {
 
 func (t *otTx) Commit() (err error) {
 	method := MethodTxCommit
-	onDefer := recordMetric(t.ctx, t.cfg.Instruments, t.cfg, method, "", nil)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(t.ctx)
+	defer metric.Record(t.cfg, method, &err)
 
 	var span trace.Span
 	if filterSpan(t.ctx, t.cfg.SpanOptions, method, "", nil) {
@@ -62,11 +60,9 @@ func (t *otTx) Commit() (err error) {
 
 func (t *otTx) Rollback() (err error) {
 	method := MethodTxRollback
-	onDefer := recordMetric(t.ctx, t.cfg.Instruments, t.cfg, method, "", nil)
 
-	defer func() {
-		onDefer(err)
-	}()
+	metric := startDurationMetric(t.ctx)
+	defer metric.Record(t.cfg, method, &err)
 
 	var span trace.Span
 	if filterSpan(t.ctx, t.cfg.SpanOptions, method, "", nil) {

--- a/utils.go
+++ b/utils.go
@@ -22,7 +22,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
 
 	internalsemconv "github.com/XSAM/otelsql/internal/semconv"
@@ -92,9 +91,17 @@ func (s *durationMetric) RecordQuery(cfg *config, method Method, query string, a
 func (s *durationMetric) record(cfg *config, method Method, getterAttributes []attribute.KeyValue, errp *error) {
 	duration := timeNow().Sub(s.startTime)
 
+	methodBase, methodHasBase := cfg.metricMethodAttrs[method]
+
 	var err error
 	if errp != nil {
 		err = *errp
+	}
+
+	// Fast path: success, no dynamic getters, known method.
+	if methodHasBase && err == nil && len(getterAttributes) == 0 {
+		cfg.Instruments.duration.RecordSet(s.ctx, duration.Seconds(), methodBase.set)
+		return
 	}
 
 	var (
@@ -112,16 +119,19 @@ func (s *durationMetric) record(cfg *config, method Method, getterAttributes []a
 		}
 	}
 
-	// number of attributes + InstrumentAttributesGetter + InstrumentErrorAttributesGetter + estimated 2 from recordDuration.
+	methodAttrs := methodBase.attrs
+	if !methodHasBase {
+		methodAttrs = getMethodAttributes(method, cfg.Attributes)
+	}
+
 	attributes := make(
 		[]attribute.KeyValue,
-		len(cfg.Attributes),
-		len(cfg.Attributes)+len(getterAttributes)+len(getterErrAttributes)+1+len(errAttributes),
+		len(methodAttrs),
+		len(methodAttrs)+len(getterAttributes)+len(getterErrAttributes)+len(errAttributes),
 	)
-	copy(attributes, cfg.Attributes)
+	copy(attributes, methodAttrs)
 	attributes = append(attributes, getterAttributes...)
 	attributes = append(attributes, getterErrAttributes...)
-	attributes = append(attributes, semconv.DBOperationName(string(method)))
 	attributes = append(attributes, errAttributes...)
 
 	cfg.Instruments.duration.RecordSet(

--- a/utils.go
+++ b/utils.go
@@ -30,12 +30,8 @@ import (
 
 var timeNow = time.Now
 
-func recordSpanErrorDeferred(span trace.Span, opts SpanOptions, err *error) {
-	recordSpanError(span, opts, *err)
-}
-
 func recordSpanError(span trace.Span, opts SpanOptions, err error) {
-	if span == nil {
+	if span == nil || !span.IsRecording() {
 		return
 	}
 
@@ -57,66 +53,82 @@ func recordSpanError(span trace.Span, opts SpanOptions, err error) {
 	}
 }
 
-func recordDuration(
-	ctx context.Context,
-	instruments *instruments,
-	cfg *config,
-	duration time.Duration,
-	attributes []attribute.KeyValue,
-	method Method,
-	err error,
-) {
-	attributes = append(attributes, semconv.DBOperationName(string(method)))
-	if err != nil && (!cfg.DisableSkipErrMeasurement || !errors.Is(err, driver.ErrSkip)) {
-		attributes = append(attributes, internalsemconv.ErrorTypeAttributes(err)...)
+// recordSpanErrorDeferred is used when using `defer` to record a span error.
+// It takes a pointer to the caller's error so the value of the error is read correctly.
+func recordSpanErrorDeferred(span trace.Span, opts SpanOptions, errp *error) {
+	recordSpanError(span, opts, *errp)
+}
+
+type durationMetric struct {
+	ctx       context.Context
+	startTime time.Time
+}
+
+func startDurationMetric(ctx context.Context) durationMetric {
+	return durationMetric{
+		ctx:       ctx,
+		startTime: timeNow(),
+	}
+}
+
+func (s *durationMetric) Record(cfg *config, method Method, err *error) {
+	var getterAttributes []attribute.KeyValue
+	if cfg.InstrumentAttributesGetter != nil {
+		getterAttributes = cfg.InstrumentAttributesGetter(s.ctx, method, "", nil)
 	}
 
-	instruments.duration.RecordSet(
-		ctx,
+	s.record(cfg, method, getterAttributes, err)
+}
+
+func (s *durationMetric) RecordQuery(cfg *config, method Method, query string, args []driver.NamedValue, err *error) {
+	var getterAttributes []attribute.KeyValue
+	if cfg.InstrumentAttributesGetter != nil {
+		getterAttributes = cfg.InstrumentAttributesGetter(s.ctx, method, query, args)
+	}
+
+	s.record(cfg, method, getterAttributes, err)
+}
+
+func (s *durationMetric) record(cfg *config, method Method, getterAttributes []attribute.KeyValue, errp *error) {
+	duration := timeNow().Sub(s.startTime)
+
+	var err error
+	if errp != nil {
+		err = *errp
+	}
+
+	var (
+		errAttributes       []attribute.KeyValue
+		getterErrAttributes []attribute.KeyValue
+	)
+
+	if err != nil {
+		if !cfg.DisableSkipErrMeasurement || !errors.Is(err, driver.ErrSkip) {
+			errAttributes = internalsemconv.ErrorTypeAttributes(err)
+		}
+
+		if cfg.InstrumentErrorAttributesGetter != nil {
+			getterErrAttributes = cfg.InstrumentErrorAttributesGetter(err)
+		}
+	}
+
+	// number of attributes + InstrumentAttributesGetter + InstrumentErrorAttributesGetter + estimated 2 from recordDuration.
+	attributes := make(
+		[]attribute.KeyValue,
+		len(cfg.Attributes),
+		len(cfg.Attributes)+len(getterAttributes)+len(getterErrAttributes)+1+len(errAttributes),
+	)
+	copy(attributes, cfg.Attributes)
+	attributes = append(attributes, getterAttributes...)
+	attributes = append(attributes, getterErrAttributes...)
+	attributes = append(attributes, semconv.DBOperationName(string(method)))
+	attributes = append(attributes, errAttributes...)
+
+	cfg.Instruments.duration.RecordSet(
+		s.ctx,
 		duration.Seconds(),
 		attribute.NewSet(attributes...),
 	)
-}
-
-// TODO: remove instruments from arguments.
-func recordMetric(
-	ctx context.Context,
-	instruments *instruments,
-	cfg *config,
-	method Method,
-	query string,
-	args []driver.NamedValue,
-) func(error) {
-	startTime := timeNow()
-
-	return func(err error) {
-		duration := timeNow().Sub(startTime)
-
-		var getterAttributes []attribute.KeyValue
-		if cfg.InstrumentAttributesGetter != nil {
-			getterAttributes = cfg.InstrumentAttributesGetter(ctx, method, query, args)
-		}
-
-		var errAttributes []attribute.KeyValue
-
-		if err != nil {
-			if cfg.InstrumentErrorAttributesGetter != nil {
-				errAttributes = cfg.InstrumentErrorAttributesGetter(err)
-			}
-		}
-
-		// number of attributes + InstrumentAttributesGetter + InstrumentErrorAttributesGetter + estimated 2 from recordDuration.
-		attributes := make(
-			[]attribute.KeyValue,
-			len(cfg.Attributes),
-			len(cfg.Attributes)+len(getterAttributes)+len(errAttributes)+2,
-		)
-		copy(attributes, cfg.Attributes)
-		attributes = append(attributes, getterAttributes...)
-		attributes = append(attributes, errAttributes...)
-
-		recordDuration(ctx, instruments, cfg, duration, attributes, method, err)
-	}
 }
 
 var spanKindClientOption = trace.WithSpanKind(trace.SpanKindClient)

--- a/utils.go
+++ b/utils.go
@@ -130,29 +130,42 @@ func createSpan(
 	args []driver.NamedValue,
 ) (context.Context, trace.Span) {
 	spanCtx, span := cfg.Tracer.Start(ctx, cfg.SpanNameFormatter(ctx, method, query), spanKindClientOption)
-	if span.IsRecording() {
-		var dbStatementAttributes []attribute.KeyValue
-		if enableDBStatement && !cfg.SpanOptions.DisableQuery {
-			dbStatementAttributes = internalsemconv.DBQueryTextAttributes(query)
-		}
-
-		var getterAttributes []attribute.KeyValue
-		if cfg.AttributesGetter != nil {
-			getterAttributes = cfg.AttributesGetter(ctx, method, query, args)
-		}
-
-		// Allocate attributes slice (Attributes + AttributesGetter + DBQueryTextAttributes).
-		attributes := make(
-			[]attribute.KeyValue,
-			len(cfg.Attributes),
-			len(cfg.Attributes)+len(getterAttributes)+len(dbStatementAttributes),
-		)
-		copy(attributes, cfg.Attributes)
-		attributes = append(attributes, dbStatementAttributes...)
-		attributes = append(attributes, getterAttributes...)
-
-		span.SetAttributes(attributes...)
+	if !span.IsRecording() {
+		return spanCtx, span
 	}
+
+	addDBStatement := enableDBStatement && !cfg.SpanOptions.DisableQuery
+
+	// Fast path when we only have to add config attributes
+	if cfg.AttributesGetter == nil && !addDBStatement {
+		if len(cfg.Attributes) > 0 {
+			span.SetAttributes(cfg.Attributes...)
+		}
+
+		return spanCtx, span
+	}
+
+	var dbStatementAttributes []attribute.KeyValue
+	if addDBStatement {
+		dbStatementAttributes = internalsemconv.DBQueryTextAttributes(query)
+	}
+
+	var getterAttributes []attribute.KeyValue
+	if cfg.AttributesGetter != nil {
+		getterAttributes = cfg.AttributesGetter(ctx, method, query, args)
+	}
+
+	// Allocate attributes slice (Attributes + AttributesGetter + DBQueryTextAttributes).
+	attributes := make(
+		[]attribute.KeyValue,
+		len(cfg.Attributes),
+		len(cfg.Attributes)+len(getterAttributes)+len(dbStatementAttributes),
+	)
+	copy(attributes, cfg.Attributes)
+	attributes = append(attributes, dbStatementAttributes...)
+	attributes = append(attributes, getterAttributes...)
+
+	span.SetAttributes(attributes...)
 
 	return spanCtx, span
 }

--- a/utils.go
+++ b/utils.go
@@ -60,7 +60,7 @@ func recordSpanError(span trace.Span, opts SpanOptions, err error) {
 func recordDuration(
 	ctx context.Context,
 	instruments *instruments,
-	cfg config,
+	cfg *config,
 	duration time.Duration,
 	attributes []attribute.KeyValue,
 	method Method,
@@ -82,7 +82,7 @@ func recordDuration(
 func recordMetric(
 	ctx context.Context,
 	instruments *instruments,
-	cfg config,
+	cfg *config,
 	method Method,
 	query string,
 	args []driver.NamedValue,
@@ -123,7 +123,7 @@ var spanKindClientOption = trace.WithSpanKind(trace.SpanKindClient)
 
 func createSpan(
 	ctx context.Context,
-	cfg config,
+	cfg *config,
 	method Method,
 	enableDBStatement bool,
 	query string,

--- a/utils_bench_test.go
+++ b/utils_bench_test.go
@@ -40,13 +40,18 @@ var (
 )
 
 func BenchmarkRecordMetric(b *testing.B) {
-	cfg := newConfig()
-	// Prevent reallocation of Attributes slice, which increase the chance to detect data races.
-	cfg.Attributes = make([]attribute.KeyValue, 0, 10)
+	newCfg := func() *config {
+		cfg := newConfig()
+
+		// Prevent reallocation of Attributes slice, which increase the chance to detect data races.
+		cfg.Attributes = make([]attribute.KeyValue, 0, 10)
+
+		return cfg
+	}
 
 	b.Run("InstrumentAttributesGetter", func(b *testing.B) {
 		b.Run("5", func(b *testing.B) {
-			cfg := cfg
+			cfg := newCfg()
 			cfg.InstrumentAttributesGetter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 				return attrs5
 			}
@@ -69,7 +74,7 @@ func BenchmarkRecordMetric(b *testing.B) {
 		})
 
 		b.Run("10", func(b *testing.B) {
-			cfg := cfg
+			cfg := newCfg()
 			cfg.InstrumentAttributesGetter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 				return attrs10
 			}
@@ -94,15 +99,19 @@ func BenchmarkRecordMetric(b *testing.B) {
 }
 
 func BenchmarkCreateSpan(b *testing.B) {
-	cfg := newConfig()
-	cfg.Tracer = sdktrace.NewTracerProvider().Tracer("BenchmarkCreateSpan")
-	// Prevent reallocation of Attributes slice, which increase the chance to detect data races.
-	cfg.Attributes = make([]attribute.KeyValue, 0, 10)
+	newCfg := func() *config {
+		cfg := newConfig()
+		cfg.Tracer = sdktrace.NewTracerProvider().Tracer("BenchmarkCreateSpan")
+		// Prevent reallocation of Attributes slice, which increase the chance to detect data races.
+		cfg.Attributes = make([]attribute.KeyValue, 0, 10)
+
+		return cfg
+	}
 
 	b.Run("AttributesGetter", func(b *testing.B) {
 		b.Run("5", func(b *testing.B) {
 			ctx := b.Context()
-			cfg := cfg
+			cfg := newCfg()
 			cfg.AttributesGetter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 				return attrs5
 			}
@@ -118,7 +127,7 @@ func BenchmarkCreateSpan(b *testing.B) {
 
 		b.Run("10", func(b *testing.B) {
 			ctx := b.Context()
-			cfg := cfg
+			cfg := newCfg()
 			cfg.AttributesGetter = func(_ context.Context, _ Method, _ string, _ []driver.NamedValue) []attribute.KeyValue {
 				return attrs10
 			}
@@ -135,7 +144,7 @@ func BenchmarkCreateSpan(b *testing.B) {
 
 	b.Run("Never Sampling", func(b *testing.B) {
 		ctx := b.Context()
-		cfg := cfg
+		cfg := newCfg()
 		cfg.Tracer = sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.NeverSample())).
 			Tracer("BenchmarkCreateSpan")
 

--- a/utils_bench_test.go
+++ b/utils_bench_test.go
@@ -60,15 +60,8 @@ func BenchmarkRecordMetric(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					recordFunc := recordMetric(
-						context.Background(),
-						cfg.Instruments,
-						cfg,
-						MethodStmtQuery,
-						"SELECT 1",
-						nil,
-					)
-					recordFunc(nil)
+					metric := startDurationMetric(context.Background())
+					metric.RecordQuery(cfg, MethodStmtQuery, "SELECT 1", nil, nil)
 				}
 			})
 		})
@@ -83,15 +76,8 @@ func BenchmarkRecordMetric(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					recordFunc := recordMetric(
-						context.Background(),
-						cfg.Instruments,
-						cfg,
-						MethodStmtQuery,
-						"SELECT 1",
-						nil,
-					)
-					recordFunc(nil)
+					metric := startDurationMetric(context.Background())
+					metric.RecordQuery(cfg, MethodStmtQuery, "SELECT 1", nil, nil)
 				}
 			})
 		})

--- a/utils_test.go
+++ b/utils_test.go
@@ -725,13 +725,13 @@ func TestRecordMetric(t *testing.T) {
 				timeNow = time.Now
 			})
 
-			recordFunc := recordMetric(context.Background(), cfg.Instruments, cfg, tt.method, tt.query, tt.args)
+			metric := startDurationMetric(context.Background())
 
 			timeNow = func() time.Time {
 				return time.Unix(3, 0)
 			}
 
-			recordFunc(tt.err)
+			metric.RecordQuery(cfg, tt.method, tt.query, tt.args, &tt.err)
 
 			var metricsData metricdata.ResourceMetrics
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -42,7 +42,6 @@ func TestRecordSpanError(t *testing.T) {
 		opts          SpanOptions
 		err           error
 		expectedError bool
-		nilSpan       bool
 	}{
 		{
 			name:          "no error",
@@ -83,42 +82,36 @@ func TestRecordSpanError(t *testing.T) {
 			opts:          SpanOptions{RecordError: func(_ error) bool { return true }},
 			expectedError: true,
 		},
-		{
-			name:          "nil span",
-			err:           nil,
-			nilSpan:       true,
-			expectedError: false,
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if !tc.nilSpan {
-				// Create a span
-				sr, provider := newTracerProvider()
-				tracer := provider.Tracer("test")
-				// Not using the spans from the SDK due to the limited data access.
-				_, _ = tracer.Start(context.Background(), "test")
+			// Create a span
+			sr, provider := newTracerProvider()
+			tracer := provider.Tracer("test")
+			// Not using the spans from the SDK due to the limited data access.
+			_, _ = tracer.Start(context.Background(), "test")
 
-				// Get the span
-				spanList := sr.Started()
-				require.Len(t, spanList, 1)
-				span := spanList[0]
+			// Get the span
+			spanList := sr.Started()
+			require.Len(t, spanList, 1)
+			span := spanList[0]
 
-				// Update the span
-				recordSpanError(span, tc.opts, tc.err)
+			// Update the span
+			recordSpanError(span, tc.opts, tc.err)
 
-				// Check result
-				if tc.expectedError {
-					assert.Equal(t, codes.Error, span.Status().Code)
-				} else {
-					assert.Equal(t, codes.Unset, span.Status().Code)
-				}
+			// Check result
+			if tc.expectedError {
+				assert.Equal(t, codes.Error, span.Status().Code)
 			} else {
-				recordSpanError(nil, tc.opts, tc.err)
+				assert.Equal(t, codes.Unset, span.Status().Code)
 			}
 		})
 	}
+
+	t.Run("nil span", func(_ *testing.T) {
+		recordSpanError(nil, SpanOptions{}, nil)
+	})
 }
 
 func newTracerProvider() (*tracetest.SpanRecorder, trace.TracerProvider) {
@@ -717,21 +710,26 @@ func TestRecordMetric(t *testing.T) {
 			cfg := newConfig(
 				append(tt.cfgOptions, WithMeterProvider(meterProvider), WithAttributes(defaultattribute))...)
 
-			timeNow = func() time.Time {
-				return time.Unix(1, 0)
-			}
-
 			t.Cleanup(func() {
 				timeNow = time.Now
 			})
 
-			metric := startDurationMetric(context.Background())
+			func() {
+				timeNow = func() time.Time {
+					return time.Unix(1, 0)
+				}
 
-			timeNow = func() time.Time {
-				return time.Unix(3, 0)
-			}
+				var metricErr error
 
-			metric.RecordQuery(cfg, tt.method, tt.query, tt.args, &tt.err)
+				metric := startDurationMetric(context.Background())
+				defer metric.RecordQuery(cfg, tt.method, tt.query, tt.args, &metricErr)
+
+				timeNow = func() time.Time {
+					return time.Unix(3, 0)
+				}
+
+				metricErr = tt.err
+			}()
 
 			var metricsData metricdata.ResourceMetrics
 


### PR DESCRIPTION
Good day,

I was looking at some traces and noticed that otelsql was taking a bit more time then I wanted. 
This PR contains some performance improvements that, so let me know what you think.

Thanks for reviewing and have a great day!

[benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) results:
```
goos: linux
goarch: amd64
pkg: github.com/XSAM/otelsql
cpu: AMD Ryzen 7 Pro 7735U with Radeon Graphics     
                                              │ c44ff0aae900c1cef8415f1a7ba37c7d28bd78e7.txt │ aac67109800e63556bde543ace8340b6d7346c4e.txt │
                                              │                    sec/op                    │       sec/op        vs base                  │
ConnQueryContext/NeverSample-16                                                 1008.5n ± 3%          260.4n ± 2%  -74.17% (p=0.000 n=10)
ConnQueryContext/Default-16                                                     1752.0n ± 2%          816.5n ± 3%  -53.39% (p=0.000 n=10)
ConnExecContext/Default-16                                                       777.0n ± 0%          465.2n ± 1%  -40.12% (p=0.000 n=10)
ConnExecContext/NeverSample-16                                                   412.2n ± 1%          118.5n ± 1%  -71.26% (p=0.000 n=10)
ConnResetSession/Default-16                                                      754.1n ± 0%          352.2n ± 1%  -53.30% (p=0.000 n=10)
ConnResetSession/NeverSample-16                                                  417.4n ± 1%          118.3n ± 1%  -71.67% (p=0.000 n=10)
ConnBeginTx/Default-16                                                          1652.0n ± 1%          751.5n ± 1%  -54.51% (p=0.000 n=10)
ConnBeginTx/NeverSample-16                                                       965.4n ± 1%          270.3n ± 1%  -72.00% (p=0.000 n=10)
NewRows-16                                                                       527.9n ± 1%          342.3n ± 1%  -35.14% (p=0.000 n=10)
Rows_Next/NeverSample-16                                                        2.0160n ± 0%         0.6087n ± 1%  -69.81% (p=0.000 n=10)
Rows_Next/Default-16                                                            2.0155n ± 1%         0.6089n ± 0%  -69.79% (p=0.000 n=10)
Rows_Next/DefaultWithRowsNextEvent-16                                            26.56n ± 0%          24.58n ± 0%   -7.45% (p=0.000 n=10)
Rows_Close/Default-16                                                            987.1n ± 1%          387.2n ± 1%  -60.77% (p=0.000 n=10)
Rows_Close/NeverSample-16                                                        645.8n ± 1%          148.1n ± 1%  -77.07% (p=0.000 n=10)
NewStmt-16                                                                      10.230n ± 0%          1.248n ± 0%  -87.80% (p=0.000 n=10)
StmtExecContext/Default-16                                                       794.9n ± 1%          469.6n ± 1%  -40.93% (p=0.000 n=10)
StmtExecContext/NeverSample-16                                                   419.7n ± 0%          120.7n ± 1%  -71.25% (p=0.000 n=10)
StmtQueryContext/Default-16                                                     1832.0n ± 1%          879.9n ± 1%  -51.97% (p=0.000 n=10)
StmtQueryContext/NeverSample-16                                                 1100.0n ± 1%          269.6n ± 1%  -75.49% (p=0.000 n=10)
RecordMetric/InstrumentAttributesGetter/5-16                                     416.8n ± 1%
RecordMetric/InstrumentAttributesGetter/10-16                                    1.188µ ± 0%
CreateSpan/AttributesGetter/5-16                                                 484.6n ± 0%
CreateSpan/AttributesGetter/10-16                                                744.1n ± 0%
CreateSpan/Never_Sampling-16                                                     81.39n ± 0%
geomean                                                                          316.6n               105.9n       -63.77%                ¹
¹ benchmark set differs from baseline; geomeans may not be comparable

                                              │ c44ff0aae900c1cef8415f1a7ba37c7d28bd78e7.txt │ aac67109800e63556bde543ace8340b6d7346c4e.txt │
                                              │                     B/op                     │       B/op        vs base                    │
ConnQueryContext/NeverSample-16                                                2098.0 ± 0%           448.0 ± 0%  -78.65% (p=0.000 n=10)
ConnQueryContext/Default-16                                                   3.677Ki ± 0%         1.877Ki ± 0%  -48.95% (p=0.000 n=10)
ConnExecContext/Default-16                                                    1.619Ki ± 0%         1.056Ki ± 0%  -34.80% (p=0.000 n=10)
ConnExecContext/NeverSample-16                                                  761.0 ± 0%           184.0 ± 0%  -75.82% (p=0.000 n=10)
ConnResetSession/Default-16                                                    1530.0 ± 0%           760.0 ± 0%  -50.33% (p=0.000 n=10)
ConnResetSession/NeverSample-16                                                 760.5 ± 0%           184.0 ± 0%  -75.81% (p=0.000 n=10)
ConnBeginTx/Default-16                                                        3.223Ki ± 0%         1.533Ki ± 0%  -52.42% (p=0.000 n=10)
ConnBeginTx/NeverSample-16                                                     1762.0 ± 0%           416.0 ± 0%  -76.39% (p=0.000 n=10)
NewRows-16                                                                      736.0 ± 0%           240.0 ± 0%  -67.39% (p=0.000 n=10)
Rows_Next/NeverSample-16                                                        0.000 ± 0%           0.000 ± 0%        ~ (p=1.000 n=10) ¹
Rows_Next/Default-16                                                            0.000 ± 0%           0.000 ± 0%        ~ (p=1.000 n=10) ¹
Rows_Next/DefaultWithRowsNextEvent-16                                           0.000 ± 0%           0.000 ± 0%        ~ (p=1.000 n=10) ¹
Rows_Close/Default-16                                                          2106.0 ± 0%           841.0 ± 0%  -60.07% (p=0.000 n=10)
Rows_Close/NeverSample-16                                                      1337.0 ± 0%           264.0 ± 0%  -80.25% (p=0.000 n=10)
NewStmt-16                                                                      0.000 ± 0%           0.000 ± 0%        ~ (p=1.000 n=10) ¹
StmtExecContext/Default-16                                                    1.619Ki ± 0%         1.056Ki ± 0%  -34.80% (p=0.000 n=10)
StmtExecContext/NeverSample-16                                                  761.0 ± 0%           184.0 ± 0%  -75.82% (p=0.000 n=10)
StmtQueryContext/Default-16                                                   3.677Ki ± 0%         1.877Ki ± 0%  -48.95% (p=0.000 n=10)
StmtQueryContext/NeverSample-16                                                2098.0 ± 0%           448.0 ± 0%  -78.65% (p=0.000 n=10)
RecordMetric/InstrumentAttributesGetter/5-16                                    857.0 ± 0%
RecordMetric/InstrumentAttributesGetter/10-16                                 2.401Ki ± 0%
CreateSpan/AttributesGetter/5-16                                              1.281Ki ± 0%
CreateSpan/AttributesGetter/10-16                                             2.031Ki ± 0%
CreateSpan/Never_Sampling-16                                                    160.0 ± 0%
geomean                                                                                    ²                     -57.13%                ³ ²
¹ all samples are equal
² summaries must be >0 to compute geomean
³ benchmark set differs from baseline; geomeans may not be comparable

                                              │ c44ff0aae900c1cef8415f1a7ba37c7d28bd78e7.txt │ aac67109800e63556bde543ace8340b6d7346c4e.txt │
                                              │                  allocs/op                   │    allocs/op      vs base                    │
ConnQueryContext/NeverSample-16                                                15.000 ± 0%           9.000 ± 0%  -40.00% (p=0.000 n=10)
ConnQueryContext/Default-16                                                     19.00 ± 0%           12.00 ± 0%  -36.84% (p=0.000 n=10)
ConnExecContext/Default-16                                                      8.000 ± 0%           6.000 ± 0%  -25.00% (p=0.000 n=10)
ConnExecContext/NeverSample-16                                                  6.000 ± 0%           4.000 ± 0%  -33.33% (p=0.000 n=10)
ConnResetSession/Default-16                                                     8.000 ± 0%           5.000 ± 0%  -37.50% (p=0.000 n=10)
ConnResetSession/NeverSample-16                                                 6.000 ± 0%           4.000 ± 0%  -33.33% (p=0.000 n=10)
ConnBeginTx/Default-16                                                          17.00 ± 0%           11.00 ± 0%  -35.29% (p=0.000 n=10)
ConnBeginTx/NeverSample-16                                                     13.000 ± 0%           9.000 ± 0%  -30.77% (p=0.000 n=10)
NewRows-16                                                                      6.000 ± 0%           4.000 ± 0%  -33.33% (p=0.000 n=10)
Rows_Next/NeverSample-16                                                        0.000 ± 0%           0.000 ± 0%        ~ (p=1.000 n=10) ¹
Rows_Next/Default-16                                                            0.000 ± 0%           0.000 ± 0%        ~ (p=1.000 n=10) ¹
Rows_Next/DefaultWithRowsNextEvent-16                                           0.000 ± 0%           0.000 ± 0%        ~ (p=1.000 n=10) ¹
Rows_Close/Default-16                                                          11.000 ± 0%           6.000 ± 0%  -45.45% (p=0.000 n=10)
Rows_Close/NeverSample-16                                                       9.000 ± 0%           5.000 ± 0%  -44.44% (p=0.000 n=10)
NewStmt-16                                                                      0.000 ± 0%           0.000 ± 0%        ~ (p=1.000 n=10) ¹
StmtExecContext/Default-16                                                      8.000 ± 0%           6.000 ± 0%  -25.00% (p=0.000 n=10)
StmtExecContext/NeverSample-16                                                  6.000 ± 0%           4.000 ± 0%  -33.33% (p=0.000 n=10)
StmtQueryContext/Default-16                                                     19.00 ± 0%           12.00 ± 0%  -36.84% (p=0.000 n=10)
StmtQueryContext/NeverSample-16                                                15.000 ± 0%           9.000 ± 0%  -40.00% (p=0.000 n=10)
RecordMetric/InstrumentAttributesGetter/5-16                                    3.000 ± 0%
RecordMetric/InstrumentAttributesGetter/10-16                                   4.000 ± 0%
CreateSpan/AttributesGetter/5-16                                                5.000 ± 0%
CreateSpan/AttributesGetter/10-16                                               5.000 ± 0%
CreateSpan/Never_Sampling-16                                                    3.000 ± 0%
geomean                                                                                    ²                     -29.36%                ³ ²
¹ all samples are equal
² summaries must be >0 to compute geomean
³ benchmark set differs from baseline; geomeans may not be comparable
```