### PR TITLE
Protect released changelog in CI

### DIFF
--- a/.github/workflows/protect-released-changelog.yml
+++ b/.github/workflows/protect-released-changelog.yml
@@ -1,0 +1,28 @@
+# This action against that any PR targeting the main branch touches released
+# sections in CHANGELOG file. If change to released CHANGELOG is required, like
+# doing a release, add the \"Unlock Released Changelog\" label to disable this action.
+
+name: Protect released changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  protect-released-changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Unlock Released Changelog')}}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Protect the released changelog
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          ./.github/workflows/scripts/verify_released_changelog.sh "$BASE_REF"

--- a/.github/workflows/scripts/verify_released_changelog.sh
+++ b/.github/workflows/scripts/verify_released_changelog.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TARGET="${1:?Must provide target ref}"
+
+FILE="CHANGELOG.md"
+TEMP_DIR=$(mktemp -d)
+echo "Temp folder: $TEMP_DIR"
+
+# Only the latest commit of the feature branch is available
+# automatically. To diff with the base branch, we need to
+# fetch that too (and we only need its latest commit).
+git fetch origin "${TARGET}" --depth=1
+
+# Checkout the previous version on the base branch of the changelog to tmpfolder
+git --work-tree="$TEMP_DIR" checkout FETCH_HEAD $FILE
+
+PREVIOUS_FILE="$TEMP_DIR/$FILE"
+CURRENT_FILE="$FILE"
+PREVIOUS_LOCKED_FILE="$TEMP_DIR/previous_locked_section.md"
+CURRENT_LOCKED_FILE="$TEMP_DIR/current_locked_section.md"
+
+# Extract released sections from the previous version
+awk '/^<!-- Released section -->/ {flag=1} /^<!-- Released section ended -->/ {flag=0} flag' "$PREVIOUS_FILE" > "$PREVIOUS_LOCKED_FILE"
+
+# Extract released sections from the current version
+awk '/^<!-- Released section -->/ {flag=1} /^<!-- Released section ended -->/ {flag=0} flag' "$CURRENT_FILE" > "$CURRENT_LOCKED_FILE"
+
+# Compare the released sections
+if ! diff -q "$PREVIOUS_LOCKED_FILE" "$CURRENT_LOCKED_FILE"; then
+    echo "Error: The released sections of the changelog file have been modified."
+    diff "$PREVIOUS_LOCKED_FILE" "$CURRENT_LOCKED_FILE"
+    rm -rf "$TEMP_DIR"
+    false
+fi
+
+rm -rf "$TEMP_DIR"
+echo "The released sections remain unchanged."

--- a/.github/workflows/scripts/verify_released_changelog.sh
+++ b/.github/workflows/scripts/verify_released_changelog.sh
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Copyright Sam Xie
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -euo pipefail
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `db.client.operation.duration` histogram now uses the explicit bucket boundaries recommended by the OTel Semantic Conventions (`0.001` to `10` seconds) instead of the SDK defaults, which placed virtually all database operations in the first bucket. (#632)
 
+<!-- Released section -->
+<!-- Don't change this section unless doing release -->
+
 ## [0.43.0] - 2026-07-12
 
 ### Removed
@@ -537,6 +540,8 @@ It contains instrumentation for trace and depends on OTel `v0.18.0`.
 - CI files.
 - Example code for a basic usage.
 - Apache-2.0 license.
+
+<!-- Released section ended -->
 
 [Go 1.26]: https://go.dev/doc/go1.26
 [Go 1.25]: https://go.dev/doc/go1.25


### PR DESCRIPTION
Per https://github.com/XSAM/otelsql/pull/632#issuecomment-5266761772

This PR adds a new action in CI to protect released sections in the changelog from being changed. It compares the released sections in the changelog from the base branch to the current PR. It fails if a change happens.

Apply "Unlock Released Changelog" to bypass this check when doing a new release.

Prior art: https://github.com/open-telemetry/opentelemetry-go/pull/5560