### PR TITLE
Add SpanOptions.RowsChildOfQuery to make sql.rows spans children of query spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The next release will require at least [Go 1.26].
 
 - Support testing of [Go 1.27]. (#650)
 - Add `WithSpanErrorAttributesGetter` option to set additional attributes (e.g., `db.response.status_code`) on spans when an operation returns an error. (#651)
+- Add `SpanOptions.RowsChildOfQuery` to create `sql.rows` spans as children of the `sql.conn.query` or `sql.stmt.query` span that produced them, so concurrent queries can be correlated with their result iteration. (#652)
 
 ### Changed
 

--- a/config.go
+++ b/config.go
@@ -140,6 +140,20 @@ type SpanOptions struct {
 	// OmitRows if set to true will suppress sql.rows spans
 	OmitRows bool
 
+	// RowsChildOfQuery, if set to true, will create sql.rows spans as children of
+	// the sql.conn.query or sql.stmt.query span that produced the rows, instead of
+	// as siblings under the caller's span.
+	//
+	// This builds an explicit causal relationship between a query span and the
+	// span that measures iterating over its result set, which is useful when
+	// multiple queries run concurrently under the same parent span. Note that the
+	// rows span will start right before the query span ends, so the child span
+	// will appear after its parent on the timeline.
+	//
+	// If the query span is not created (e.g., OmitConnQuery is set or SpanFilter
+	// returns false), the sql.rows span falls back to the caller's span as its parent.
+	RowsChildOfQuery bool
+
 	// OmitConnectorConnect if set to true will suppress sql.connector.connect spans
 	OmitConnectorConnect bool
 

--- a/conn.go
+++ b/conn.go
@@ -161,7 +161,7 @@ func (c *otConn) QueryContext(
 		return nil, err
 	}
 
-	return newRows(ctx, rows, c.cfg), nil
+	return newRows(rowsContext(ctx, queryCtx, c.cfg), rows, c.cfg), nil
 }
 
 func (c *otConn) PrepareContext(ctx context.Context, query string) (stmt driver.Stmt, err error) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -28,11 +28,12 @@ import (
 )
 
 const (
-	testSpanFilterOmit = "spanFilterOmit"
-	testSpanFilterNil  = "spanFilterNil"
-	testSpanFilterKeep = "spanFilterKeep"
-	testQueryString    = "query"
-	testLegacy         = "legacy"
+	testSpanFilterOmit   = "spanFilterOmit"
+	testSpanFilterNil    = "spanFilterNil"
+	testSpanFilterKeep   = "spanFilterKeep"
+	testQueryString      = "query"
+	testLegacy           = "legacy"
+	testRowsChildOfQuery = "rowsChildOfQuery"
 )
 
 type MockConn interface {
@@ -389,6 +390,39 @@ func TestOtConn_QueryContext(t *testing.T) {
 	args := []driver.NamedValue{{Value: "foo"}}
 	expectedAttrs := []attribute.KeyValue{semconv.DBQueryTextKey.String(query)}
 
+	testCases := []struct {
+		name             string
+		error            bool
+		noParentSpan     bool
+		disableQuery     bool
+		attrs            []attribute.KeyValue
+		attributesGetter AttributesGetter
+	}{
+		{
+			name:  "no error",
+			attrs: expectedAttrs,
+		},
+		{
+			name:         "no query db.statement",
+			disableQuery: true,
+		},
+		{
+			name:  "with error",
+			error: true,
+			attrs: expectedAttrs,
+		},
+		{
+			name:         "no parent span",
+			noParentSpan: true,
+			attrs:        expectedAttrs,
+		},
+		{
+			name:             "with attribute getter",
+			attributesGetter: getDummyAttributesGetter(),
+			attrs:            expectedAttrs,
+		},
+	}
+
 	for _, omitConnQuery := range []bool{true, false} {
 		var testname string
 		if omitConnQuery {
@@ -396,119 +430,77 @@ func TestOtConn_QueryContext(t *testing.T) {
 		}
 
 		t.Run(testname, func(t *testing.T) {
-			for _, spanFilterFn := range []SpanFilter{nil, omit, keep} {
-				testname := testSpanFilterOmit
-				if spanFilterFn == nil {
-					testname = testSpanFilterNil
-				} else if spanFilterFn(nil, "", "", []driver.NamedValue{}) {
-					testname = testSpanFilterKeep
+			for _, rowsChildOfQuery := range []bool{true, false} {
+				var testname string
+				if rowsChildOfQuery {
+					testname = testRowsChildOfQuery
 				}
 
 				t.Run(testname, func(t *testing.T) {
-					testCases := []struct {
-						name             string
-						error            bool
-						noParentSpan     bool
-						disableQuery     bool
-						attrs            []attribute.KeyValue
-						attributesGetter AttributesGetter
-					}{
-						{
-							name:  "no error",
-							attrs: expectedAttrs,
-						},
-						{
-							name:         "no query db.statement",
-							disableQuery: true,
-						},
-						{
-							name:  "with error",
-							error: true,
-							attrs: expectedAttrs,
-						},
-						{
-							name:         "no parent span",
-							noParentSpan: true,
-							attrs:        expectedAttrs,
-						},
-						{
-							name:             "with attribute getter",
-							attributesGetter: getDummyAttributesGetter(),
-							attrs:            expectedAttrs,
-						},
-					}
+					for _, spanFilterFn := range []SpanFilter{nil, omit, keep} {
+						testname := testSpanFilterOmit
+						if spanFilterFn == nil {
+							testname = testSpanFilterNil
+						} else if spanFilterFn(nil, "", "", []driver.NamedValue{}) {
+							testname = testSpanFilterKeep
+						}
 
-					for _, tc := range testCases {
-						t.Run(tc.name, func(t *testing.T) {
-							// Prepare traces
-							ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+						t.Run(testname, func(t *testing.T) {
+							for _, tc := range testCases {
+								t.Run(tc.name, func(t *testing.T) {
+									// Prepare traces
+									ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
 
-							// New conn
-							cfg := newConfig()
-							cfg.Tracer = tracer
-							cfg.SpanOptions.DisableQuery = tc.disableQuery
-							cfg.SpanOptions.OmitConnQuery = omitConnQuery
-							cfg.SpanOptions.SpanFilter = spanFilterFn
-							cfg.AttributesGetter = tc.attributesGetter
-							cfg.InstrumentAttributesGetter = InstrumentAttributesGetter(tc.attributesGetter)
-							mc := newMockConn(tc.error)
-							otelConn := newConn(mc, cfg)
+									// New conn
+									cfg := newConfig()
+									cfg.Tracer = tracer
+									cfg.SpanOptions.DisableQuery = tc.disableQuery
+									cfg.SpanOptions.OmitConnQuery = omitConnQuery
+									cfg.SpanOptions.RowsChildOfQuery = rowsChildOfQuery
+									cfg.SpanOptions.SpanFilter = spanFilterFn
+									cfg.AttributesGetter = tc.attributesGetter
+									cfg.InstrumentAttributesGetter = InstrumentAttributesGetter(tc.attributesGetter)
+									mc := newMockConn(tc.error)
+									otelConn := newConn(mc, cfg)
 
-							rows, err := otelConn.QueryContext(ctx, query, args)
-							if tc.error {
-								require.Error(t, err)
-							} else {
-								require.NoError(t, err)
-							}
+									rows, err := otelConn.QueryContext(ctx, query, args)
+									if tc.error {
+										require.Error(t, err)
+									} else {
+										require.NoError(t, err)
+									}
 
-							spanList := sr.Ended()
+									spanList := sr.Ended()
 
-							omit := omitConnQuery
-							if !omit {
-								omit = !filterSpan(ctx, cfg.SpanOptions, MethodConnQuery, query, args)
-							}
+									omit := omitConnQuery
+									if !omit {
+										omit = !filterSpan(ctx, cfg.SpanOptions, MethodConnQuery, query, args)
+									}
 
-							expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, omit)
-							// One dummy span and one span created in QueryContext
-							require.Len(t, spanList, expectedSpanCount)
+									expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, omit)
+									// One dummy span and one span created in QueryContext
+									require.Len(t, spanList, expectedSpanCount)
 
-							assertSpanList(t, spanList, spanAssertionParameter{
-								parentSpan:         dummySpan,
-								error:              tc.error,
-								expectedAttributes: append(cfg.Attributes, tc.attrs...),
-								method:             MethodConnQuery,
-								noParentSpan:       tc.noParentSpan,
-								ctx:                mc.queryContextCtx,
-								omitSpan:           omit,
-								attributesGetter:   tc.attributesGetter,
-								query:              query,
-								args:               args,
-							})
+									assertSpanList(t, spanList, spanAssertionParameter{
+										parentSpan:         dummySpan,
+										error:              tc.error,
+										expectedAttributes: append(cfg.Attributes, tc.attrs...),
+										method:             MethodConnQuery,
+										noParentSpan:       tc.noParentSpan,
+										ctx:                mc.queryContextCtx,
+										omitSpan:           omit,
+										attributesGetter:   tc.attributesGetter,
+										query:              query,
+										args:               args,
+									})
 
-							assert.Equal(t, 1, mc.queryContextCount)
-							assert.Equal(t, "query", mc.queryContextQuery)
+									assert.Equal(t, 1, mc.queryContextCount)
+									assert.Equal(t, "query", mc.queryContextQuery)
 
-							if !tc.error {
-								otelRows, ok := rows.(*otRows)
-								require.True(t, ok)
-
-								if dummySpan != nil && !omit {
-									assert.Equal(
-										t,
-										dummySpan.SpanContext().TraceID(),
-										otelRows.span.SpanContext().TraceID(),
-									)
-
-									// Get a span from started span list
-									startedSpanList := sr.Started()
-									require.Len(t, startedSpanList, expectedSpanCount+1)
-									span := startedSpanList[expectedSpanCount]
-									// Make sure this span is the same as the span from otelRows
-									require.Equal(t, otelRows.span.SpanContext().SpanID(), span.SpanContext().SpanID())
-
-									// The span that creates in newRows() is the child of the dummySpan
-									assert.Equal(t, dummySpan.SpanContext().SpanID(), span.Parent().SpanID())
-								}
+									if !tc.error {
+										assertRowsSpan(ctx, t, sr, cfg, rows, dummySpan, omit)
+									}
+								})
 							}
 						})
 					}

--- a/rows.go
+++ b/rows.go
@@ -40,6 +40,17 @@ type otRows struct {
 	onClose func(err error)
 }
 
+// rowsContext returns the context that should be used to create the sql.rows span.
+// When SpanOptions.RowsChildOfQuery is set, the query span's context is used so the
+// rows span becomes a child of the query span; otherwise the caller's context is used.
+func rowsContext(ctx, queryCtx context.Context, cfg config) context.Context {
+	if cfg.SpanOptions.RowsChildOfQuery {
+		return queryCtx
+	}
+
+	return ctx
+}
+
 func newRows(ctx context.Context, rows driver.Rows, cfg config) *otRows {
 	var span trace.Span
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -15,6 +15,7 @@
 package otelsql
 
 import (
+	"context"
 	"database/sql/driver"
 	"errors"
 	"testing"
@@ -212,6 +213,20 @@ func TestOtRows_Next(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRowsContext(t *testing.T) {
+	type ctxKey struct{}
+
+	ctx := context.Background()
+	queryCtx := context.WithValue(ctx, ctxKey{}, "query")
+
+	var cfg config
+
+	assert.Equal(t, ctx, rowsContext(ctx, queryCtx, cfg))
+
+	cfg.SpanOptions.RowsChildOfQuery = true
+	assert.Equal(t, queryCtx, rowsContext(ctx, queryCtx, cfg))
 }
 
 func TestNewRows(t *testing.T) {

--- a/stmt.go
+++ b/stmt.go
@@ -127,7 +127,7 @@ func (s *otStmt) QueryContext(
 		}
 	}
 
-	return newRows(ctx, rows, s.cfg), nil
+	return newRows(rowsContext(ctx, queryCtx, s.cfg), rows, s.cfg), nil
 }
 
 func (s *otStmt) CheckNamedValue(namedValue *driver.NamedValue) error {

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -275,71 +275,81 @@ func TestOtStmt_QueryContext(t *testing.T) {
 		}
 
 		t.Run(testname, func(t *testing.T) {
-			for _, spanFilterFn := range []SpanFilter{nil, omit, keep} {
-				testname := testSpanFilterOmit
-				if spanFilterFn == nil {
-					testname = testSpanFilterNil
-				} else if spanFilterFn(nil, "", "", []driver.NamedValue{}) {
-					testname = testSpanFilterKeep
+			for _, rowsChildOfQuery := range []bool{true, false} {
+				var testname string
+				if rowsChildOfQuery {
+					testname = testRowsChildOfQuery
 				}
 
 				t.Run(testname, func(t *testing.T) {
-					for _, tc := range testCases {
-						t.Run(tc.name, func(t *testing.T) {
-							// Prepare traces
-							ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
+					for _, spanFilterFn := range []SpanFilter{nil, omit, keep} {
+						testname := testSpanFilterOmit
+						if spanFilterFn == nil {
+							testname = testSpanFilterNil
+						} else if spanFilterFn(nil, "", "", []driver.NamedValue{}) {
+							testname = testSpanFilterKeep
+						}
 
-							var ms MockStmt
-							if legacy {
-								ms = newMockLegacyStmt(tc.error)
-							} else {
-								ms = newMockStmt(tc.error)
-							}
+						t.Run(testname, func(t *testing.T) {
+							for _, tc := range testCases {
+								t.Run(tc.name, func(t *testing.T) {
+									// Prepare traces
+									ctx, sr, tracer, dummySpan := prepareTraces(tc.noParentSpan)
 
-							// New stmt
-							cfg := newConfig()
-							cfg.Tracer = tracer
-							cfg.SpanOptions.DisableQuery = tc.disableQuery
-							cfg.SpanOptions.SpanFilter = spanFilterFn
-							cfg.AttributesGetter = tc.attributesGetter
-							cfg.InstrumentAttributesGetter = InstrumentAttributesGetter(tc.attributesGetter)
-							stmt := newStmt(ms, cfg, query, nil)
-							// Query
-							rows, err := stmt.QueryContext(ctx, args)
-							if tc.error {
-								require.Error(t, err)
-							} else {
-								require.NoError(t, err)
-							}
+									var ms MockStmt
+									if legacy {
+										ms = newMockLegacyStmt(tc.error)
+									} else {
+										ms = newMockStmt(tc.error)
+									}
 
-							spanList := sr.Ended()
-							omit := !filterSpan(ctx, cfg.SpanOptions, MethodStmtQuery, query, args)
-							expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, omit)
-							// One dummy span and a span created in tx
-							require.Len(t, spanList, expectedSpanCount)
+									// New stmt
+									cfg := newConfig()
+									cfg.Tracer = tracer
+									cfg.SpanOptions.DisableQuery = tc.disableQuery
+									cfg.SpanOptions.RowsChildOfQuery = rowsChildOfQuery
+									cfg.SpanOptions.SpanFilter = spanFilterFn
+									cfg.AttributesGetter = tc.attributesGetter
+									cfg.InstrumentAttributesGetter = InstrumentAttributesGetter(tc.attributesGetter)
+									stmt := newStmt(ms, cfg, query, nil)
+									// Query
+									rows, err := stmt.QueryContext(ctx, args)
+									if tc.error {
+										require.Error(t, err)
+									} else {
+										require.NoError(t, err)
+									}
 
-							assertSpanList(t, spanList, spanAssertionParameter{
-								parentSpan:         dummySpan,
-								error:              tc.error,
-								expectedAttributes: append(cfg.Attributes, tc.attrs...),
-								method:             MethodStmtQuery,
-								noParentSpan:       tc.noParentSpan,
-								attributesGetter:   tc.attributesGetter,
-								omitSpan:           omit,
-								query:              query,
-								args:               args,
-							})
+									spanList := sr.Ended()
+									omit := !filterSpan(ctx, cfg.SpanOptions, MethodStmtQuery, query, args)
+									expectedSpanCount := getExpectedSpanCount(tc.noParentSpan, omit)
+									// One dummy span and a span created in tx
+									require.Len(t, spanList, expectedSpanCount)
 
-							assert.Equal(t, 1, ms.QueryContextCount())
+									assertSpanList(t, spanList, spanAssertionParameter{
+										parentSpan:         dummySpan,
+										error:              tc.error,
+										expectedAttributes: append(cfg.Attributes, tc.attrs...),
+										method:             MethodStmtQuery,
+										noParentSpan:       tc.noParentSpan,
+										attributesGetter:   tc.attributesGetter,
+										omitSpan:           omit,
+										query:              query,
+										args:               args,
+									})
 
-							if ms.QueryContextArgs() != nil {
-								assert.Equal(t, []driver.NamedValue{{Value: "foo"}}, ms.QueryContextArgs())
-							} else {
-								assert.Equal(t, []driver.Value{"foo"}, ms.QueryArgs())
-							}
+									assert.Equal(t, 1, ms.QueryContextCount())
 
-							if !tc.error {
-								assert.IsType(t, &otRows{}, rows)
+									if ms.QueryContextArgs() != nil {
+										assert.Equal(t, []driver.NamedValue{{Value: "foo"}}, ms.QueryContextArgs())
+									} else {
+										assert.Equal(t, []driver.Value{"foo"}, ms.QueryArgs())
+									}
+
+									if !tc.error {
+										assertRowsSpan(ctx, t, sr, cfg, rows, dummySpan, omit)
+									}
+								})
 							}
 						})
 					}

--- a/utils_test.go
+++ b/utils_test.go
@@ -267,6 +267,53 @@ func assertSpanList(
 	}
 }
 
+// assertRowsSpan verifies the span created in newRows() by a query method.
+// querySpanOmitted reports whether the query span (sql.conn.query or sql.stmt.query)
+// was not created, in which case the rows span falls back to the caller's span as its parent.
+func assertRowsSpan(
+	ctx context.Context,
+	t *testing.T,
+	sr *tracetest.SpanRecorder,
+	cfg config,
+	rows driver.Rows,
+	dummySpan trace.Span,
+	querySpanOmitted bool,
+) {
+	t.Helper()
+
+	otelRows, ok := rows.(*otRows)
+	require.True(t, ok)
+
+	if !filterSpan(ctx, cfg.SpanOptions, MethodRows, "", nil) {
+		assert.Nil(t, otelRows.span)
+		return
+	}
+
+	require.NotNil(t, otelRows.span)
+
+	endedSpanList := sr.Ended()
+	startedSpanList := sr.Started()
+	// The rows span is started but not ended until rows.Close() is called.
+	require.Len(t, startedSpanList, len(endedSpanList)+1)
+	rowsSpan := startedSpanList[len(endedSpanList)]
+	// Make sure this span is the same as the span from otelRows
+	require.Equal(t, otelRows.span.SpanContext().SpanID(), rowsSpan.SpanContext().SpanID())
+
+	switch {
+	case cfg.SpanOptions.RowsChildOfQuery && !querySpanOmitted:
+		// The query span is the last ended span, and the rows span is its child.
+		querySpan := endedSpanList[len(endedSpanList)-1]
+		assert.Equal(t, querySpan.SpanContext().TraceID(), rowsSpan.SpanContext().TraceID())
+		assert.Equal(t, querySpan.SpanContext().SpanID(), rowsSpan.Parent().SpanID())
+	case dummySpan != nil:
+		// The rows span is the child of the dummySpan
+		assert.Equal(t, dummySpan.SpanContext().TraceID(), rowsSpan.SpanContext().TraceID())
+		assert.Equal(t, dummySpan.SpanContext().SpanID(), rowsSpan.Parent().SpanID())
+	default:
+		assert.False(t, rowsSpan.Parent().IsValid())
+	}
+}
+
 func getExpectedSpanCount(noParentSpan bool, omitSpan bool) int {
 	if !noParentSpan {
 		if !omitSpan {


### PR DESCRIPTION
## Summary

Fixes #561.

When multiple queries run concurrently under the same parent span, `sql.conn.query` and `sql.rows` spans are emitted as siblings with no way to tell which rows span belongs to which query. As discussed in the issue, this adds an opt-in option to propagate the query span's context into the rows span.

- Add `SpanOptions.RowsChildOfQuery`. When set, the `sql.rows` span is created from the query span's context, so it becomes a child of the `sql.conn.query` or `sql.stmt.query` span that produced it.
- When the query span is not created (`OmitConnQuery`, or `SpanFilter` returns false), the rows span falls back to the caller's span as its parent, same as today.
- Default is `false`, so existing behavior is unchanged.

The doc comment notes the trade-off raised in #108: the rows span starts right before the query span ends, so the child appears after its parent on the timeline.

## Test plan

- [x] `TestOtConn_QueryContext` and `TestOtStmt_QueryContext` now run with `RowsChildOfQuery` on and off, and assert the rows span's parent in each case (query span, dummy parent span, or no parent).
- [x] `TestRowsContext` unit test for the context selection.
- [x] `make lint license-check` and `go test -race ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)