### PR TITLE
Fix OpenTelemetry release note wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The next release will require at least [Go 1.26].
 ### Changed
 
 - Replace `ErrorTypeAttributes` with `ErrorTypeAttribute` to avoid allocating an additional slice. (#643)
-- Upgrade OTel Semconv to `v1.46.0`. (#644)
+- Upgrade OTel to `v1.46.0`. (#644)
 
 ### Fixed
 
@@ -39,7 +39,7 @@ The next release will require at least [Go 1.26].
 ### Changed
 
 - ~~Upgrade OTel Semconv to `v1.40.0`.~~ (#606)
-- Upgrade OTel Semconv to `v1.44.0`. (#615)
+- Upgrade OTel to `v1.44.0`. (#615)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The next release will require at least [Go 1.26].
 
 ### Changed
 
-- ~~Upgrade OTel Semconv to `v1.40.0`.~~ (#606)
+- ~~Upgrade OTel to `v1.40.0`.~~ (#606)
 - Upgrade OTel to `v1.44.0`. (#615)
 
 ### Fixed


### PR DESCRIPTION
Corrects the current and v0.43.0 release notes so OpenTelemetry module upgrades are not described as semantic-convention migrations. The source continues to use `semconv/v1.40.0`; this PR changes release-note wording only.
