### PR TITLE
Use gomodguard_v2 in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,7 @@ linters:
     - godot
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan


### PR DESCRIPTION
golangci-lint now uses the supported `gomodguard_v2` linter instead of deprecated `gomodguard`.